### PR TITLE
Clarify email notifications code and tests to add more destinations

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -55,8 +55,8 @@ var opts struct {
 		SMTPTLS            bool          `long:"smtp-tls" env:"SMTP_TLS" description:"enable SMTP TLS"`
 		SMTPStartTLS       bool          `long:"smtp-starttls" env:"SMTP_STARTTLS" description:"enable SMTP StartTLS"`
 		SMTPTimeOut        time.Duration `long:"smtp-timeout" env:"SMTP_TIMEOUT" default:"10s" description:"SMTP TCP connection timeout"`
-		From               string        `long:"from" env:"FROM" description:"SMTP from email"`
-		To                 []string      `long:"to" env:"TO" description:"SMTP to email(s)" env-delim:","`
+		FromEmail          string        `long:"from" env:"FROM" description:"SMTP from email"`
+		ToEmails           []string      `long:"to" env:"TO" description:"SMTP to email(s)" env-delim:","`
 		MaxLogLines        int           `long:"max-log" env:"MAX_LOG" default:"100" description:"max number of log lines name"`
 		HostName           string        `long:"host" env:"HOSTNAME" description:"host name running cronn"`
 	} `group:"notify" namespace:"notify" env-namespace:"CRONN_NOTIFY"`
@@ -145,8 +145,8 @@ func makeNotifier() *notify.Service {
 	if !opts.Notify.EnabledError && !opts.Notify.EnabledCompletion {
 		return nil
 	}
-	if opts.Notify.From == "" {
-		opts.Notify.From = "cronn@" + makeHostName()
+	if opts.Notify.FromEmail == "" {
+		opts.Notify.FromEmail = "cronn@" + makeHostName()
 	}
 	return notify.NewService(
 		notify.Params{
@@ -167,8 +167,8 @@ func makeNotifier() *notify.Service {
 				ContentType: "text/html",
 				Charset:     "utf-8",
 			},
-			FromEmail: opts.Notify.From,
-			ToEmails:  opts.Notify.To,
+			FromEmail: opts.Notify.FromEmail,
+			ToEmails:  opts.Notify.ToEmails,
 		})
 }
 

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -21,13 +21,14 @@ func Test_makeHostName(t *testing.T) {
 
 func Test_makeNotifier(t *testing.T) {
 	opts.Notify.EnabledCompletion, opts.Notify.EnabledError = false, false
-	opts.Notify.From = ""
+	opts.Notify.FromEmail = ""
+	opts.Notify.ToEmails = []string{"test@example.com"}
 	assert.Nil(t, makeNotifier())
 
 	opts.Notify.EnabledCompletion = true
 	notif := makeNotifier()
 	require.NotNil(t, notif)
-	assert.Equal(t, "cronn@"+makeHostName(), opts.Notify.From,
+	assert.Equal(t, "cronn@"+makeHostName(), opts.Notify.FromEmail,
 		"side effect of creating notifier with empty From "+
 			"is setting the From based on hostname")
 }

--- a/app/notify/notify.go
+++ b/app/notify/notify.go
@@ -47,15 +47,21 @@ type SendersParams struct {
 }
 
 // NewService makes notification service with optional template files
-func NewService(notifyParams Params, emailParams SendersParams) *Service {
-	emailService := notify.NewEmail(emailParams.SMTPParams)
-
+func NewService(notifyParams Params, sendersParams SendersParams) *Service {
 	res := Service{
-		destinations: []notify.Notifier{emailService},
-		fromEmail:    emailParams.FromEmail,
-		toEmail:      emailParams.ToEmails,
+		destinations: []notify.Notifier{},
+		fromEmail:    sendersParams.FromEmail,
+		toEmail:      sendersParams.ToEmails,
 		onError:      notifyParams.EnabledError,
 		onCompletion: notifyParams.EnabledCompletion,
+	}
+
+	if len(sendersParams.ToEmails) != 0 {
+		res.destinations = append(res.destinations, notify.NewEmail(sendersParams.SMTPParams))
+	}
+
+	if len(res.destinations) == 0 {
+		return nil
 	}
 
 	res.errorTemplate = defaultErrorTemplate

--- a/app/notify/notify_test.go
+++ b/app/notify/notify_test.go
@@ -11,8 +11,14 @@ import (
 	"github.com/umputun/cronn/app/notify/mocks"
 )
 
-func TestMakeErrorHTMLDefault(t *testing.T) {
+func TestService_EmptyDestinations(t *testing.T) {
 	svc := NewService(Params{}, SendersParams{})
+	require.Nil(t, svc)
+}
+
+func TestMakeErrorHTMLDefault(t *testing.T) {
+	svc := NewService(Params{}, SendersParams{ToEmails: []string{"test@example.com"}})
+	require.NotNil(t, svc)
 	res, err := svc.MakeErrorHTML("* * * * *", "ls -la", "some log")
 	require.NoError(t, err)
 	assert.Contains(t, res, "<li>Command: <span class=\"bold\">ls -la</span></li>")
@@ -21,20 +27,23 @@ func TestMakeErrorHTMLDefault(t *testing.T) {
 }
 
 func TestMakeErrorHTMLCustom(t *testing.T) {
-	svc := NewService(Params{ErrorTemplate: "testfiles/err.tmpl"}, SendersParams{})
+	svc := NewService(Params{ErrorTemplate: "testfiles/err.tmpl"}, SendersParams{ToEmails: []string{"test@example.com"}})
+	require.NotNil(t, svc)
 	res, err := svc.MakeErrorHTML("* * * * *", "ls -la", "some log")
 	require.NoError(t, err)
 	assert.Contains(t, res, "Command failed: ls -la")
 	assert.Contains(t, res, "Spec: * * * * *")
 
-	svc = NewService(Params{ErrorTemplate: "testfiles/err-bad.tmpl"}, SendersParams{})
+	svc = NewService(Params{ErrorTemplate: "testfiles/err-bad.tmpl"}, SendersParams{ToEmails: []string{"test@example.com"}})
+	require.NotNil(t, svc)
 	res, err = svc.MakeErrorHTML("* * * * *", "ls -la", "some log")
 	require.NoError(t, err)
 	assert.Contains(t, res, "<li>Command: <span class=\"bold\">ls -la</span></li>")
 }
 
 func TestMakeCompletionHTMLDefault(t *testing.T) {
-	svc := NewService(Params{}, SendersParams{})
+	svc := NewService(Params{}, SendersParams{ToEmails: []string{"test@example.com"}})
+	require.NotNil(t, svc)
 	res, err := svc.MakeCompletionHTML("* * * * *", "ls -la")
 	require.NoError(t, err)
 	assert.Contains(t, res, "<li>Command: <span class=\"bold\">ls -la</span></li>")
@@ -43,31 +52,36 @@ func TestMakeCompletionHTMLDefault(t *testing.T) {
 }
 
 func TestMakeCompletionHTMLCustom(t *testing.T) {
-	svc := NewService(Params{CompletionTemplate: "testfiles/completed.tmpl"}, SendersParams{})
+	svc := NewService(Params{CompletionTemplate: "testfiles/completed.tmpl"}, SendersParams{ToEmails: []string{"test@example.com"}})
+	require.NotNil(t, svc)
 	res, err := svc.MakeCompletionHTML("* * * * *", "ls -la")
 	require.NoError(t, err)
 	assert.Contains(t, res, "Command done: ls -la")
 	assert.Contains(t, res, "Spec: * * * * *")
 
-	svc = NewService(Params{CompletionTemplate: "testfiles/completed-bad.tmpl"}, SendersParams{})
+	svc = NewService(Params{CompletionTemplate: "testfiles/completed-bad.tmpl"}, SendersParams{ToEmails: []string{"test@example.com"}})
 	res, err = svc.MakeCompletionHTML("* * * * *", "ls -la")
 	require.NoError(t, err)
 	assert.Contains(t, res, "<li>Command: <span class=\"bold\">ls -la</span></li>")
 }
 
 func TestService_IsOnCompletion(t *testing.T) {
-	svc := NewService(Params{EnabledCompletion: true}, SendersParams{})
+	svc := NewService(Params{EnabledCompletion: true}, SendersParams{ToEmails: []string{"test@example.com"}})
+	require.NotNil(t, svc)
 	assert.True(t, svc.IsOnCompletion())
 
-	svc = NewService(Params{EnabledCompletion: false}, SendersParams{})
+	svc = NewService(Params{EnabledCompletion: false}, SendersParams{ToEmails: []string{"test@example.com"}})
+	require.NotNil(t, svc)
 	assert.False(t, svc.IsOnCompletion())
 }
 
 func TestService_IsOnError(t *testing.T) {
-	svc := NewService(Params{EnabledError: true}, SendersParams{})
+	svc := NewService(Params{EnabledError: true}, SendersParams{ToEmails: []string{"test@example.com"}})
+	require.NotNil(t, svc)
 	assert.True(t, svc.IsOnError())
 
-	svc = NewService(Params{EnabledError: false}, SendersParams{})
+	svc = NewService(Params{EnabledError: false}, SendersParams{ToEmails: []string{"test@example.com"}})
+	require.NotNil(t, svc)
 	assert.False(t, svc.IsOnError())
 }
 


### PR DESCRIPTION
The case of nil service was not checked before, and it doesn't make sense to create email notifications in case the destination email is not set. Also, I've clarified the parameters names in `main.go` to be consistent with `notify` package.