### PR TITLE
Start sending successful notifications, fix telegram messages formatting

### DIFF
--- a/app/notify/notify.go
+++ b/app/notify/notify.go
@@ -130,7 +130,7 @@ func (s *Service) Send(ctx context.Context, subj, text string) error {
 		err = errors.Join(err, notify.Send(ctx, s.destinations, destination, text))
 	}
 	for _, telegramDestination := range s.telegramDestinations {
-		destination := fmt.Sprintf("telegram:%s?type=HTML", telegramDestination)
+		destination := fmt.Sprintf("telegram:%s?parseMode=HTML", telegramDestination)
 		err = errors.Join(err, notify.Send(ctx, s.destinations, destination, notify.TelegramSupportedHTML(text)))
 	}
 	for _, webhookURL := range s.webhookURLs {
@@ -272,7 +272,7 @@ var (
 		<ul>
 			<li>Command: <span class="bold">{{.Command}}</span></li>
 			<li>Spec: <span class="bold">{{.Spec}}</span></li>
-		</ul>>
+		</ul>
 	</body>
 </html>
 `

--- a/app/service/service.go
+++ b/app/service/service.go
@@ -152,12 +152,17 @@ func (s *Scheduler) jobFunc(r crontab.JobSpec, sched Schedule) cron.FuncJob {
 			return fmt.Errorf("failed to initiate resumer for %+v: %w", cmd, rerr)
 		}
 
-		if err = s.executeCommand(cmd, s.Stdout); err != nil {
-			ctxTimeout, cancel := context.WithTimeout(context.Background(), s.NotifyTimeout)
-			defer cancel()
-			if e := s.notify(ctxTimeout, r, err.Error()); e != nil {
-				return fmt.Errorf("failed to notify: %w", err)
-			}
+		err = s.executeCommand(cmd, s.Stdout)
+		ctxTimeout, cancel := context.WithTimeout(context.Background(), s.NotifyTimeout)
+		defer cancel()
+		var errMsg string
+		if err != nil {
+			errMsg = err.Error()
+		}
+		if e := s.notify(ctxTimeout, r, errMsg); e != nil {
+			return fmt.Errorf("failed to notify: %w", err)
+		}
+		if err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Previously, no successful notification would be sent despite `--notify.enabled-complete` flag.

Also, telegram parseMode=HTML was set incorrectly and because of that HTML formatting for Telegram messages was not working.