### PR TITLE
feat: add manual run button for jobs in web UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@
 ## Web UI Architecture
 - Server implements `JobEventHandler` interface to receive job events
 - Uses Go templates with `html/template` and `embed` for static files
+- **IMPORTANT**: Templates and static files are embedded at compile time - must rebuild after any changes to templates or CSS
 - HTMX for 5-second auto-refresh polling
 - Cookie-based persistence for theme and view preferences
 - SHA256 hashing for job identity tracking

--- a/app/main.go
+++ b/app/main.go
@@ -138,6 +138,12 @@ func main() {
 		jitterDuration = opts.JitterDuration
 	}
 
+	// create manual trigger channel if web UI is enabled
+	var manualTrigger chan service.ManualJobRequest
+	if opts.Web.Enabled {
+		manualTrigger = make(chan service.ManualJobRequest, 100)
+	}
+
 	// initialize web server if enabled
 	var eventHandler service.JobEventHandler
 	if opts.Web.Enabled {
@@ -146,6 +152,7 @@ func main() {
 			DBPath:         opts.Web.DBPath,
 			UpdateInterval: opts.Web.UpdateInterval,
 			Version:        revision,
+			ManualTrigger:  manualTrigger,
 		}
 		webServer, err := web.New(cfg)
 		if err != nil {
@@ -180,6 +187,7 @@ func main() {
 		DeDup:             service.NewDeDup(opts.DeDup),
 		NotifyTimeout:     opts.Notify.TimeOut,
 		JobEventHandler:   eventHandler,
+		ManualTrigger:     manualTrigger,
 	}
 
 	cronService.RepeaterDefaults.Attempts = opts.Repeater.Attempts

--- a/app/web/static/style.css
+++ b/app/web/static/style.css
@@ -1133,9 +1133,7 @@ code {
 }
 
 .htmx-indicator { display: none; }
-/* Same scoping as above to avoid global reveal during auto-refresh */
 .htmx-indicator.htmx-request { display: inline-block; }
-.btn-compact.htmx-request + .htmx-indicator { display: inline-block; }
 
 .htmx-request.btn-run-now {
     opacity: 0.6;

--- a/app/web/static/style.css
+++ b/app/web/static/style.css
@@ -189,7 +189,7 @@ code {
 }
 
 .control-btn {
-    transition: all 0.15s ease;
+    transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
 .control-btn:hover {
@@ -336,6 +336,7 @@ code {
     position: absolute;
     top: var(--spacing-md);
     right: var(--spacing-md);
+    z-index: 10;
 }
 
 .status-indicator {
@@ -388,7 +389,20 @@ code {
 }
 
 .job-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     margin-bottom: var(--spacing-md);
+    position: relative;
+    z-index: 1;
+    padding-right: 40px; /* Space for status icon */
+}
+
+.job-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
 }
 
 .job-schedule {
@@ -506,7 +520,7 @@ code {
 }
 
 .jobs-table tbody tr {
-    transition: all 0.15s ease;
+    transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
 .jobs-table tbody tr:hover {
@@ -934,5 +948,176 @@ code {
     
     .command-text {
         max-width: 120px;
+    }
+}
+
+/* Run Now button styles */
+.btn-run-now {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 16px;
+    background: var(--success);
+    color: white;
+    border: none;
+    border-radius: var(--radius);
+    font-size: var(--text-sm);
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 0.2s ease, box-shadow 0.2s ease;
+    white-space: nowrap;
+}
+
+.btn-run-now:hover:not(:disabled) {
+    background: #15803d; /* darker green */
+    box-shadow: 0 4px 12px rgba(34, 197, 94, 0.25);
+}
+
+.btn-run-now:active:not(:disabled) {
+    box-shadow: 0 2px 6px rgba(34, 197, 94, 0.25);
+}
+
+.btn-run-now:disabled {
+    background: var(--border);
+    color: var(--text-muted);
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+.btn-run-now.btn-small {
+    padding: 3px 8px;
+    font-size: 11px;
+    background: transparent;
+    color: var(--color-text-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    cursor: pointer;
+    font-weight: 500;
+    white-space: nowrap;
+}
+
+.btn-run-now.btn-small:hover:not(:disabled) {
+    background: var(--color-surface-hover);
+    color: var(--color-primary);
+    border-color: var(--color-primary);
+}
+
+.btn-run-now.btn-small:active:not(:disabled) {
+    background: var(--color-primary);
+    color: white;
+    border-color: var(--color-primary);
+}
+
+.btn-run-now.btn-small:disabled {
+    background: transparent;
+    border-color: var(--color-border);
+    color: var(--color-text-muted);
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+.btn-run-now.btn-small .icon {
+    width: 10px;
+    height: 10px;
+}
+
+.btn-compact {
+    padding: 3px 8px;
+    font-size: 11px;
+    background: transparent;
+    color: var(--color-text-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    cursor: pointer;
+    font-weight: 500;
+    white-space: nowrap;
+    transition: none !important;
+}
+
+.btn-compact:hover:not(:disabled) {
+    background: var(--color-surface-hover);
+    color: var(--color-primary);
+    border-color: var(--color-primary);
+}
+
+.btn-compact:active:not(:disabled) {
+    background: var(--color-primary);
+    color: white;
+    border-color: var(--color-primary);
+}
+
+.btn-compact:disabled {
+    background: transparent;
+    border-color: var(--color-border);
+    color: var(--color-text-muted);
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+.btn-compact .icon {
+    width: 10px;
+    height: 10px;
+}
+
+.btn-compact span {
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.btn-run-now .icon {
+    flex-shrink: 0;
+}
+
+
+/* Job actions in table */
+.td-actions {
+    white-space: nowrap;
+    text-align: center;
+}
+
+.th-actions {
+    text-align: center;
+    width: 100px;
+}
+
+/* Spinner for loading state */
+.spinner-small {
+    display: inline-block;
+    width: 14px;
+    height: 14px;
+    border: 2px solid var(--border);
+    border-top-color: var(--primary);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+}
+
+.spinner-small.inline {
+    vertical-align: middle;
+    margin-right: 4px;
+}
+
+.htmx-indicator {
+    display: none;
+}
+
+.htmx-request .htmx-indicator {
+    display: inline-block;
+}
+
+.htmx-request.btn-run-now {
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
     }
 }

--- a/app/web/static/style.css
+++ b/app/web/static/style.css
@@ -307,6 +307,7 @@ code {
     transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
     position: relative;
     box-shadow: var(--shadow-sm);
+    contain: layout;
 }
 
 .job-card:hover {
@@ -389,20 +390,22 @@ code {
 }
 
 .job-header {
-    display: flex;
+    display: grid;
+    grid-template-columns: auto 1fr 56px;
     align-items: center;
-    justify-content: space-between;
     margin-bottom: var(--spacing-md);
     position: relative;
     z-index: 1;
     padding-right: 40px; /* Space for status icon */
+    gap: 12px;
 }
 
 .job-header-actions {
     display: flex;
     align-items: center;
+    justify-content: flex-end;
     gap: 4px;
-    flex-shrink: 0;
+    width: 56px;
 }
 
 .job-schedule {
@@ -481,12 +484,40 @@ code {
     background: var(--color-surface);
     border-radius: 12px;
     border: 1px solid var(--color-border);
-    overflow: hidden;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
 }
 
 .jobs-table {
     width: 100%;
     border-collapse: collapse;
+}
+
+/* Minimum column widths for stable layout */
+.th-status, .td-status {
+    min-width: 80px;
+}
+
+.th-schedule, .td-schedule {
+    min-width: 100px;
+}
+
+.th-command, .td-command {
+    min-width: 200px;
+}
+
+.th-next, .td-next {
+    min-width: 140px;
+    white-space: nowrap;
+}
+
+.th-last, .td-last {
+    min-width: 120px;
+    white-space: nowrap;
+}
+
+.th-actions, .td-actions {
+    min-width: 60px;
 }
 
 .jobs-table thead {
@@ -525,7 +556,6 @@ code {
 
 .jobs-table tbody tr:hover {
     background: var(--color-surface-hover);
-    transform: translateX(2px);
 }
 
 .jobs-table td {
@@ -685,6 +715,7 @@ code {
 .time-value {
     color: var(--color-text);
     line-height: 1.3;
+    font-size: var(--text-sm);
 }
 
 .time-value small {
@@ -751,13 +782,10 @@ code {
 }
 
 /* HTMX indicator */
-.htmx-indicator {
-    display: none;
-}
-
-.htmx-request .htmx-indicator {
-    display: inline-block;
-}
+.htmx-indicator { display: none; }
+/* Show only for the element making the request or its adjacent spinner */
+.htmx-indicator.htmx-request { display: inline-block; }
+.btn-compact.htmx-request + .htmx-indicator { display: inline-block; }
 
 /* Responsive design */
 @media (max-width: 768px) {
@@ -1033,10 +1061,15 @@ code {
     border-radius: var(--radius-sm);
     display: inline-flex;
     align-items: center;
+    justify-content: center;
     gap: 3px;
     cursor: pointer;
     font-weight: 500;
     white-space: nowrap;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    min-width: 56px;
+    height: 20px;
     transition: none !important;
 }
 
@@ -1061,14 +1094,9 @@ code {
 }
 
 .btn-compact .icon {
-    width: 10px;
-    height: 10px;
-}
-
-.btn-compact span {
-    font-weight: 500;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
+    width: 12px;
+    height: 12px;
+    flex-shrink: 0;
 }
 
 .btn-run-now .icon {
@@ -1079,7 +1107,8 @@ code {
 /* Job actions in table */
 .td-actions {
     white-space: nowrap;
-    text-align: center;
+    text-align: left;
+    padding-left: 12px;
 }
 
 .th-actions {
@@ -1103,13 +1132,10 @@ code {
     margin-right: 4px;
 }
 
-.htmx-indicator {
-    display: none;
-}
-
-.htmx-request .htmx-indicator {
-    display: inline-block;
-}
+.htmx-indicator { display: none; }
+/* Same scoping as above to avoid global reveal during auto-refresh */
+.htmx-indicator.htmx-request { display: inline-block; }
+.btn-compact.htmx-request + .htmx-indicator { display: inline-block; }
 
 .htmx-request.btn-run-now {
     opacity: 0.6;

--- a/app/web/templates/base.html
+++ b/app/web/templates/base.html
@@ -108,7 +108,7 @@
     <!-- HTMX and extensions -->
     <script src="https://unpkg.com/htmx.org@2.0.3" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/htmx-ext-response-targets@2.0.1/response-targets.js"></script>
-    
+
     <!-- Handle refresh-jobs event -->
     <script>
         document.body.addEventListener('refresh-jobs', function(evt) {

--- a/app/web/templates/dashboard.html
+++ b/app/web/templates/dashboard.html
@@ -20,7 +20,7 @@
     <div id="jobs-container" 
          hx-get="/api/jobs" 
          hx-trigger="load, every 5s"
-         hx-swap="innerHTML"
+         hx-swap="innerHTML settle:0ms"
          class="jobs-container {{.ViewMode}}">
         <!-- Jobs will be loaded here via HTMX -->
         <div class="loading">

--- a/app/web/templates/partials/jobs.html
+++ b/app/web/templates/partials/jobs.html
@@ -39,33 +39,21 @@
         </div>
         <div></div><!-- Spacer for grid -->
         <div class="job-header-actions">
-            {{if and .Enabled (not .IsRunning)}}
             <button class="btn-compact"
+                    {{if and .Enabled (not .IsRunning)}}
                     hx-post="/api/jobs/{{.ID}}/run"
                     hx-swap="none"
                     hx-indicator="#run-spinner-{{.ID}}"
-                    hx-on::after-request="this.disabled=true; setTimeout(() => this.disabled=false, 2000)">
+                    hx-on::after-request="this.disabled=true; setTimeout(() => this.disabled=false, 2000)"
+                    {{else}}
+                    disabled
+                    {{end}}>
                 <svg class="icon" width="12" height="12" viewBox="0 0 24 24" fill="none">
                     <path d="M5 3l14 9-14 9V3z" fill="currentColor"/>
                 </svg>
                 <span>Run</span>
             </button>
-            <span id="run-spinner-{{.ID}}" class="htmx-indicator spinner-small"></span>
-            {{else if .IsRunning}}
-            <button class="btn-compact" disabled>
-                <svg class="icon" width="12" height="12" viewBox="0 0 24 24" fill="none">
-                    <path d="M5 3l14 9-14 9V3z" fill="currentColor"/>
-                </svg>
-                <span>Run</span>
-            </button>
-            {{else}}
-            <button class="btn-compact" disabled>
-                <svg class="icon" width="12" height="12" viewBox="0 0 24 24" fill="none">
-                    <path d="M5 3l14 9-14 9V3z" fill="currentColor"/>
-                </svg>
-                <span>Run</span>
-            </button>
-            {{end}}
+            {{if and .Enabled (not .IsRunning)}}<span id="run-spinner-{{.ID}}" class="htmx-indicator spinner-small"></span>{{end}}
         </div>
     </div>
     
@@ -158,33 +146,21 @@
             </td>
             
             <td class="td-actions">
-                {{if and .Enabled (not .IsRunning)}}
                 <button class="btn-compact"
+                        {{if and .Enabled (not .IsRunning)}}
                         hx-post="/api/jobs/{{.ID}}/run"
                         hx-swap="none"
                         hx-indicator="#run-spinner-{{.ID}}"
-                        hx-on::after-request="this.disabled=true; setTimeout(() => this.disabled=false, 2000)">
+                        hx-on::after-request="this.disabled=true; setTimeout(() => this.disabled=false, 2000)"
+                        {{else}}
+                        disabled
+                        {{end}}>
                     <svg class="icon" width="12" height="12" viewBox="0 0 24 24" fill="none">
                         <path d="M5 3l14 9-14 9V3z" fill="currentColor"/>
                     </svg>
                     <span>Run</span>
                 </button>
-                <span id="run-spinner-{{.ID}}" class="htmx-indicator spinner-small"></span>
-                {{else if .IsRunning}}
-                <button class="btn-compact" disabled>
-                    <svg class="icon" width="12" height="12" viewBox="0 0 24 24" fill="none">
-                        <path d="M5 3l14 9-14 9V3z" fill="currentColor"/>
-                    </svg>
-                    <span>Run</span>
-                </button>
-                {{else}}
-                <button class="btn-compact" disabled>
-                    <svg class="icon" width="12" height="12" viewBox="0 0 24 24" fill="none">
-                        <path d="M5 3l14 9-14 9V3z" fill="currentColor"/>
-                    </svg>
-                    <span>Run</span>
-                </button>
-                {{end}}
+                {{if and .Enabled (not .IsRunning)}}<span id="run-spinner-{{.ID}}" class="htmx-indicator spinner-small"></span>{{end}}
             </td>
         </tr>
         {{end}}

--- a/app/web/templates/partials/jobs.html
+++ b/app/web/templates/partials/jobs.html
@@ -37,10 +37,10 @@
             </svg>
             <code>{{.Schedule}}</code>
         </div>
+        <div></div><!-- Spacer for grid -->
         <div class="job-header-actions">
             {{if and .Enabled (not .IsRunning)}}
             <button class="btn-compact"
-                    style="display: inline-flex; align-items: center; gap: 3px; padding: 3px 8px; font-size: 11px;"
                     hx-post="/api/jobs/{{.ID}}/run"
                     hx-swap="none"
                     hx-indicator="#run-spinner-{{.ID}}"
@@ -53,12 +53,17 @@
             <span id="run-spinner-{{.ID}}" class="htmx-indicator spinner-small"></span>
             {{else if .IsRunning}}
             <button class="btn-compact" disabled>
-                <div class="spinner-small inline"></div>
-                Running
+                <svg class="icon" width="12" height="12" viewBox="0 0 24 24" fill="none">
+                    <path d="M5 3l14 9-14 9V3z" fill="currentColor"/>
+                </svg>
+                <span>Run</span>
             </button>
             {{else}}
             <button class="btn-compact" disabled>
-                Run
+                <svg class="icon" width="12" height="12" viewBox="0 0 24 24" fill="none">
+                    <path d="M5 3l14 9-14 9V3z" fill="currentColor"/>
+                </svg>
+                <span>Run</span>
             </button>
             {{end}}
         </div>
@@ -154,7 +159,7 @@
             
             <td class="td-actions">
                 {{if and .Enabled (not .IsRunning)}}
-                <button class="btn-run-now btn-small"
+                <button class="btn-compact"
                         hx-post="/api/jobs/{{.ID}}/run"
                         hx-swap="none"
                         hx-indicator="#run-spinner-{{.ID}}"
@@ -162,17 +167,22 @@
                     <svg class="icon" width="12" height="12" viewBox="0 0 24 24" fill="none">
                         <path d="M5 3l14 9-14 9V3z" fill="currentColor"/>
                     </svg>
-                    Run
+                    <span>Run</span>
                 </button>
                 <span id="run-spinner-{{.ID}}" class="htmx-indicator spinner-small"></span>
                 {{else if .IsRunning}}
-                <button class="btn-run-now btn-small" disabled>
-                    <div class="spinner-small inline"></div>
-                    Running
+                <button class="btn-compact" disabled>
+                    <svg class="icon" width="12" height="12" viewBox="0 0 24 24" fill="none">
+                        <path d="M5 3l14 9-14 9V3z" fill="currentColor"/>
+                    </svg>
+                    <span>Run</span>
                 </button>
                 {{else}}
-                <button class="btn-run-now btn-small" disabled>
-                    Run
+                <button class="btn-compact" disabled>
+                    <svg class="icon" width="12" height="12" viewBox="0 0 24 24" fill="none">
+                        <path d="M5 3l14 9-14 9V3z" fill="currentColor"/>
+                    </svg>
+                    <span>Run</span>
                 </button>
                 {{end}}
             </td>

--- a/app/web/templates/partials/jobs.html
+++ b/app/web/templates/partials/jobs.html
@@ -37,6 +37,31 @@
             </svg>
             <code>{{.Schedule}}</code>
         </div>
+        <div class="job-header-actions">
+            {{if and .Enabled (not .IsRunning)}}
+            <button class="btn-compact"
+                    style="display: inline-flex; align-items: center; gap: 3px; padding: 3px 8px; font-size: 11px;"
+                    hx-post="/api/jobs/{{.ID}}/run"
+                    hx-swap="none"
+                    hx-indicator="#run-spinner-{{.ID}}"
+                    hx-on::after-request="this.disabled=true; setTimeout(() => this.disabled=false, 2000)">
+                <svg class="icon" width="12" height="12" viewBox="0 0 24 24" fill="none">
+                    <path d="M5 3l14 9-14 9V3z" fill="currentColor"/>
+                </svg>
+                <span>Run</span>
+            </button>
+            <span id="run-spinner-{{.ID}}" class="htmx-indicator spinner-small"></span>
+            {{else if .IsRunning}}
+            <button class="btn-compact" disabled>
+                <div class="spinner-small inline"></div>
+                Running
+            </button>
+            {{else}}
+            <button class="btn-compact" disabled>
+                Run
+            </button>
+            {{end}}
+        </div>
     </div>
     
     <div class="job-command">
@@ -61,6 +86,7 @@
             <span class="timing-value">{{if .LastRun.IsZero}}Never{{else}}{{humanTime .LastRun}}{{end}}</span>
         </div>
     </div>
+    
 </div>
 {{end}}
 {{end}}
@@ -74,6 +100,7 @@
             <th class="th-command">Command</th>
             <th class="th-next numeric">Next Run</th>
             <th class="th-last numeric">Last Run</th>
+            <th class="th-actions">Actions</th>
         </tr>
     </thead>
     <tbody>
@@ -123,6 +150,31 @@
             
             <td class="td-last numeric">
                 <span class="time-value">{{if .LastRun.IsZero}}Never{{else}}{{humanTime .LastRun}}{{end}}</span>
+            </td>
+            
+            <td class="td-actions">
+                {{if and .Enabled (not .IsRunning)}}
+                <button class="btn-run-now btn-small"
+                        hx-post="/api/jobs/{{.ID}}/run"
+                        hx-swap="none"
+                        hx-indicator="#run-spinner-{{.ID}}"
+                        hx-on::after-request="this.disabled=true; setTimeout(() => this.disabled=false, 2000)">
+                    <svg class="icon" width="12" height="12" viewBox="0 0 24 24" fill="none">
+                        <path d="M5 3l14 9-14 9V3z" fill="currentColor"/>
+                    </svg>
+                    Run
+                </button>
+                <span id="run-spinner-{{.ID}}" class="htmx-indicator spinner-small"></span>
+                {{else if .IsRunning}}
+                <button class="btn-run-now btn-small" disabled>
+                    <div class="spinner-small inline"></div>
+                    Running
+                </button>
+                {{else}}
+                <button class="btn-run-now btn-small" disabled>
+                    Run
+                </button>
+                {{end}}
             </td>
         </tr>
         {{end}}


### PR DESCRIPTION
## Summary
- Added manual "Run" button to trigger jobs on-demand from the web UI
- Fixed button flickering issue during HTMX auto-refresh cycles
- Improved responsive design for both card and list views

## Changes
- Added Run button to both card and list views with proper disabled states
- Implemented `/api/jobs/{id}/run` endpoint to trigger job execution
- Fixed CSS to eliminate flickering by using targeted `.htmx-indicator` rules
- Switched job-header layout from flexbox to CSS Grid for stability
- Removed unused morphdom dependencies
- Added min-width constraints to table columns for responsive design

Part of #37