### PR TITLE
fix: resolve web parser reuse and SQLite locking issues

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -148,11 +148,11 @@ func main() {
 	var eventHandler service.JobEventHandler
 	if opts.Web.Enabled {
 		cfg := web.Config{
-			CrontabFile:    opts.CrontabFile,
 			DBPath:         opts.Web.DBPath,
 			UpdateInterval: opts.Web.UpdateInterval,
 			Version:        revision,
 			ManualTrigger:  manualTrigger,
+			JobsProvider:   crontabParser,
 		}
 		webServer, err := web.New(cfg)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Fixed web server creating new parsers on every sync instead of reusing centralized parser
- Resolved SQLite "database is locked" errors under concurrent access
- Improved dependency injection and error handling

## Key Changes

### 1. Web UI Parser Reuse
- Introduced `JobsProvider` interface in web package (consumer-side pattern)
- Web server now accepts parser dependency via constructor
- Prevents resource waste and ensures consistent parser behavior
- Removes redundant parser creation on every sync cycle

### 2. SQLite Database Locking Fix
- Added RWMutex to SQLiteStore for serialized database operations
- Protected all DB operations (LoadJobs, SaveJobs, RecordExecution, Close)
- Added PRAGMA busy_timeout=5000 for additional resilience
- Eliminates "SQLITE_BUSY" errors in concurrent scenarios

### 3. Code Quality Improvements
- Enhanced error messages with more context
- Added comprehensive test coverage for error scenarios
- Fixed all test configurations to use proper dependency injection
- Improved interface documentation

## Testing
- All tests pass with race detector enabled
- Concurrent tests no longer show database locking errors
- Added specific tests for nil provider and error handling
- Test coverage maintained at 87.8%