### PR TITLE
feat: add neighbor instances selector for multi-server navigation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ Functions return concrete `*SQLiteStore` while accepting `Persistence` interface
 - **Auto-refresh polling**: `hx-trigger="load, every 5s"` for JavaScript-free real-time updates
 - **Response coordination**: `HX-Refresh: true` header triggers full page refresh when needed
 - **Event coordination**: Custom events like `refresh-jobs` coordinate updates between components
+- **Lazy-load dropdowns**: Native `<details>/<summary>` with `hx-trigger="toggle once"` for dropdowns that fetch content on first open (used in neighbors selector)
 
 ### Event-Driven Architecture
 - Server implements `JobEventHandler` interface to receive job events

--- a/app/main.go
+++ b/app/main.go
@@ -95,6 +95,7 @@ var opts struct {
 		LoginTTL           time.Duration `long:"login-ttl" env:"LOGIN_TTL" default:"24h" description:"login session TTL"`
 		DisableManual      bool          `long:"disable-manual" env:"DISABLE_MANUAL" description:"disable manual job execution"`
 		DisableCommandEdit bool          `long:"disable-command-edit" env:"DISABLE_COMMAND_EDIT" description:"disable command editing in manual run dialog"`
+		NeighborsURL       string        `long:"neighbors-url" env:"NEIGHBORS_URL" description:"URL to fetch neighbor instances JSON ([{name, url}])"`
 	} `group:"web" namespace:"web" env-namespace:"CRONN_WEB"`
 
 	Version bool `long:"version" description:"show version and exit"`
@@ -186,6 +187,7 @@ func main() {
 			Settings:           buildSettingsInfo(hostname),
 			ExecMaxLogLines:    opts.Log.ExecMaxLines,
 			LogExecMaxHist:     opts.Log.ExecMaxHist,
+			NeighborsURL:       opts.Web.NeighborsURL,
 		}
 		webServer, err := web.New(cfg)
 		if err != nil {

--- a/app/web/neighbors.go
+++ b/app/web/neighbors.go
@@ -1,0 +1,137 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	log "github.com/go-pkgz/lgr"
+)
+
+// NeighborInstance represents a neighboring cronn instance
+type NeighborInstance struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+// handleNeighbors returns the list of neighbor instances fetched from external URL
+func (s *Server) handleNeighbors(w http.ResponseWriter, _ *http.Request) {
+	if s.neighborsURL == "" {
+		http.Error(w, "Neighbors not configured", http.StatusNotFound)
+		return
+	}
+
+	// check cache (5 minute TTL)
+	s.neighborsMu.RLock()
+	if s.neighborsCache != nil && time.Since(s.neighborsCacheTime) < 5*time.Minute {
+		neighbors := s.neighborsCache
+		s.neighborsMu.RUnlock()
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(neighbors); err != nil {
+			log.Printf("[ERROR] failed to encode neighbors: %v", err)
+		}
+		return
+	}
+	s.neighborsMu.RUnlock()
+
+	// fetch from external URL
+	neighbors, err := s.fetchNeighbors()
+	if err != nil {
+		log.Printf("[ERROR] failed to fetch neighbors from %s: %v", s.neighborsURL, err)
+		http.Error(w, "Failed to fetch neighbors", http.StatusBadGateway)
+		return
+	}
+
+	// update cache
+	s.neighborsMu.Lock()
+	s.neighborsCache = neighbors
+	s.neighborsCacheTime = time.Now()
+	s.neighborsMu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(neighbors); err != nil {
+		log.Printf("[ERROR] failed to encode neighbors: %v", err)
+	}
+}
+
+// fetchNeighbors fetches neighbor instances from the configured URL (supports http://, https://, file://)
+func (s *Server) fetchNeighbors() ([]NeighborInstance, error) {
+	var body []byte
+	var err error
+
+	// handle file:// uRLs by reading from local filesystem
+	if len(s.neighborsURL) > 7 && s.neighborsURL[:7] == "file://" {
+		filePath := s.neighborsURL[7:]
+		body, err = readNeighborsFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read neighbors file %s: %w", filePath, err)
+		}
+	} else {
+		// http/https URL
+		body, err = s.fetchNeighborsHTTP()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var neighbors []NeighborInstance
+	if err := json.Unmarshal(body, &neighbors); err != nil {
+		return nil, fmt.Errorf("failed to parse neighbors JSON: %w", err)
+	}
+
+	return neighbors, nil
+}
+
+// fetchNeighborsHTTP fetches neighbors from an HTTP/HTTPS URL
+func (s *Server) fetchNeighborsHTTP() ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.neighborsURL, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch neighbors: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Printf("[WARN] failed to close response body: %v", closeErr)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024)) // 1MB limit
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	return body, nil
+}
+
+// readNeighborsFile reads neighbors from a local file with size limit
+func readNeighborsFile(path string) ([]byte, error) {
+	f, err := os.Open(path) // #nosec G304 - path comes from trusted config
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file: %w", err)
+	}
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil {
+			log.Printf("[WARN] failed to close file: %v", closeErr)
+		}
+	}()
+	data, err := io.ReadAll(io.LimitReader(f, 1024*1024)) // 1MB limit
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+	return data, nil
+}

--- a/app/web/neighbors_test.go
+++ b/app/web/neighbors_test.go
@@ -1,0 +1,216 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServer_handleNeighbors(t *testing.T) {
+	t.Run("returns 404 when neighbors not configured", func(t *testing.T) {
+		srv := &Server{neighborsURL: ""}
+		req := httptest.NewRequest(http.MethodGet, "/api/neighbors", http.NoBody)
+		w := httptest.NewRecorder()
+
+		srv.handleNeighbors(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+		assert.Contains(t, w.Body.String(), "Neighbors not configured")
+	})
+
+	t.Run("fetches from HTTP URL and caches", func(t *testing.T) {
+		neighbors := []NeighborInstance{
+			{Name: "server1", URL: "http://server1.example.com"},
+			{Name: "server2", URL: "http://server2.example.com"},
+		}
+
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(neighbors)
+		}))
+		defer mockServer.Close()
+
+		srv := &Server{neighborsURL: mockServer.URL}
+
+		req := httptest.NewRequest(http.MethodGet, "/api/neighbors", http.NoBody)
+		w := httptest.NewRecorder()
+		srv.handleNeighbors(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+		var result []NeighborInstance
+		err := json.Unmarshal(w.Body.Bytes(), &result)
+		require.NoError(t, err)
+		assert.Equal(t, neighbors, result)
+
+		assert.NotNil(t, srv.neighborsCache)
+		assert.Equal(t, neighbors, srv.neighborsCache)
+	})
+
+	t.Run("returns cached data within TTL", func(t *testing.T) {
+		cachedNeighbors := []NeighborInstance{
+			{Name: "cached", URL: "http://cached.example.com"},
+		}
+
+		srv := &Server{
+			neighborsURL:       "http://should-not-be-called.example.com",
+			neighborsCache:     cachedNeighbors,
+			neighborsCacheTime: time.Now(),
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/api/neighbors", http.NoBody)
+		w := httptest.NewRecorder()
+		srv.handleNeighbors(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var result []NeighborInstance
+		err := json.Unmarshal(w.Body.Bytes(), &result)
+		require.NoError(t, err)
+		assert.Equal(t, cachedNeighbors, result)
+	})
+
+	t.Run("fetches from file:// URL", func(t *testing.T) {
+		neighbors := []NeighborInstance{
+			{Name: "file-server1", URL: "http://file-server1.example.com"},
+		}
+
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "neighbors.json")
+		data, err := json.Marshal(neighbors)
+		require.NoError(t, err)
+		err = os.WriteFile(filePath, data, 0o600)
+		require.NoError(t, err)
+
+		srv := &Server{neighborsURL: "file://" + filePath}
+
+		req := httptest.NewRequest(http.MethodGet, "/api/neighbors", http.NoBody)
+		w := httptest.NewRecorder()
+		srv.handleNeighbors(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var result []NeighborInstance
+		err = json.Unmarshal(w.Body.Bytes(), &result)
+		require.NoError(t, err)
+		assert.Equal(t, neighbors, result)
+	})
+
+	t.Run("returns 502 when HTTP fetch fails", func(t *testing.T) {
+		srv := &Server{neighborsURL: "http://nonexistent.invalid"}
+
+		req := httptest.NewRequest(http.MethodGet, "/api/neighbors", http.NoBody)
+		w := httptest.NewRecorder()
+		srv.handleNeighbors(w, req)
+
+		assert.Equal(t, http.StatusBadGateway, w.Code)
+	})
+
+	t.Run("returns 502 when file read fails", func(t *testing.T) {
+		srv := &Server{neighborsURL: "file:///nonexistent/path/neighbors.json"}
+
+		req := httptest.NewRequest(http.MethodGet, "/api/neighbors", http.NoBody)
+		w := httptest.NewRecorder()
+		srv.handleNeighbors(w, req)
+
+		assert.Equal(t, http.StatusBadGateway, w.Code)
+	})
+
+	t.Run("returns 502 when JSON is invalid", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "invalid.json")
+		err := os.WriteFile(filePath, []byte("not valid json"), 0o600)
+		require.NoError(t, err)
+
+		srv := &Server{neighborsURL: "file://" + filePath}
+
+		req := httptest.NewRequest(http.MethodGet, "/api/neighbors", http.NoBody)
+		w := httptest.NewRecorder()
+		srv.handleNeighbors(w, req)
+
+		assert.Equal(t, http.StatusBadGateway, w.Code)
+	})
+
+	t.Run("returns 502 when HTTP server returns non-200", func(t *testing.T) {
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer mockServer.Close()
+
+		srv := &Server{neighborsURL: mockServer.URL}
+
+		req := httptest.NewRequest(http.MethodGet, "/api/neighbors", http.NoBody)
+		w := httptest.NewRecorder()
+		srv.handleNeighbors(w, req)
+
+		assert.Equal(t, http.StatusBadGateway, w.Code)
+	})
+}
+
+func TestServer_fetchNeighbors(t *testing.T) {
+	t.Run("fetches from HTTP URL", func(t *testing.T) {
+		neighbors := []NeighborInstance{
+			{Name: "test", URL: "http://test.example.com"},
+		}
+
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(neighbors)
+		}))
+		defer mockServer.Close()
+
+		srv := &Server{neighborsURL: mockServer.URL}
+		result, err := srv.fetchNeighbors()
+
+		require.NoError(t, err)
+		assert.Equal(t, neighbors, result)
+	})
+
+	t.Run("fetches from file URL", func(t *testing.T) {
+		neighbors := []NeighborInstance{
+			{Name: "file-test", URL: "http://file-test.example.com"},
+		}
+
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "neighbors.json")
+		data, err := json.Marshal(neighbors)
+		require.NoError(t, err)
+		err = os.WriteFile(filePath, data, 0o600)
+		require.NoError(t, err)
+
+		srv := &Server{neighborsURL: "file://" + filePath}
+		result, err := srv.fetchNeighbors()
+
+		require.NoError(t, err)
+		assert.Equal(t, neighbors, result)
+	})
+
+	t.Run("returns error for invalid JSON", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "invalid.json")
+		err := os.WriteFile(filePath, []byte("{invalid}"), 0o600)
+		require.NoError(t, err)
+
+		srv := &Server{neighborsURL: "file://" + filePath}
+		_, err = srv.fetchNeighbors()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse neighbors JSON")
+	})
+
+	t.Run("returns error for missing file", func(t *testing.T) {
+		srv := &Server{neighborsURL: "file:///nonexistent/file.json"}
+		_, err := srv.fetchNeighbors()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read neighbors file")
+	})
+}

--- a/app/web/static/app.js
+++ b/app/web/static/app.js
@@ -177,3 +177,83 @@ document.getElementById('history-modal').addEventListener('click', function(e) {
         }
     }
 });
+
+// neighbors dropdown functionality
+let neighborsLoaded = false;
+
+window.toggleNeighborsDropdown = function(event) {
+    event.stopPropagation();
+    const selector = document.querySelector('.neighbors-selector');
+    const dropdown = document.getElementById('neighbors-dropdown');
+    if (!selector || !dropdown) return;
+
+    const isOpen = dropdown.style.display !== 'none';
+    if (isOpen) {
+        dropdown.style.display = 'none';
+        selector.classList.remove('open');
+    } else {
+        dropdown.style.display = 'block';
+        selector.classList.add('open');
+        if (!neighborsLoaded) {
+            loadNeighbors();
+        }
+    }
+};
+
+function loadNeighbors() {
+    const dropdown = document.getElementById('neighbors-dropdown');
+    if (!dropdown) return;
+
+    const baseURL = window.BASE_URL || '';
+    fetch(baseURL + '/api/neighbors')
+        .then(function(response) {
+            if (!response.ok) throw new Error('failed to load');
+            return response.json();
+        })
+        .then(function(neighbors) {
+            neighborsLoaded = true;
+            if (neighbors.length === 0) {
+                dropdown.innerHTML = '<div class="neighbors-error">No neighbors configured</div>';
+                return;
+            }
+            let html = '<div class="neighbors-list">';
+            neighbors.forEach(function(n) {
+                html += '<a href="' + escapeHtml(n.url) + '" class="neighbor-item">' + escapeHtml(n.name) + '</a>';
+            });
+            html += '</div>';
+            dropdown.innerHTML = html;
+        })
+        .catch(function() {
+            dropdown.innerHTML = '<div class="neighbors-error">Failed to load neighbors</div>';
+        });
+}
+
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+// close neighbors dropdown when clicking outside
+document.addEventListener('click', function(e) {
+    const selector = document.querySelector('.neighbors-selector');
+    const dropdown = document.getElementById('neighbors-dropdown');
+    if (!selector || !dropdown) return;
+
+    if (!selector.contains(e.target)) {
+        dropdown.style.display = 'none';
+        selector.classList.remove('open');
+    }
+});
+
+// close neighbors dropdown on ESC
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') {
+        const selector = document.querySelector('.neighbors-selector');
+        const dropdown = document.getElementById('neighbors-dropdown');
+        if (selector && dropdown && dropdown.style.display !== 'none') {
+            dropdown.style.display = 'none';
+            selector.classList.remove('open');
+        }
+    }
+});

--- a/app/web/static/app.js
+++ b/app/web/static/app.js
@@ -178,82 +178,19 @@ document.getElementById('history-modal').addEventListener('click', function(e) {
     }
 });
 
-// neighbors dropdown functionality
-let neighborsLoaded = false;
-
-window.toggleNeighborsDropdown = function(event) {
-    event.stopPropagation();
-    const selector = document.querySelector('.neighbors-selector');
-    const dropdown = document.getElementById('neighbors-dropdown');
-    if (!selector || !dropdown) return;
-
-    const isOpen = dropdown.style.display !== 'none';
-    if (isOpen) {
-        dropdown.style.display = 'none';
-        selector.classList.remove('open');
-    } else {
-        dropdown.style.display = 'block';
-        selector.classList.add('open');
-        if (!neighborsLoaded) {
-            loadNeighbors();
-        }
-    }
-};
-
-function loadNeighbors() {
-    const dropdown = document.getElementById('neighbors-dropdown');
-    if (!dropdown) return;
-
-    const baseURL = window.BASE_URL || '';
-    fetch(baseURL + '/api/neighbors')
-        .then(function(response) {
-            if (!response.ok) throw new Error('failed to load');
-            return response.json();
-        })
-        .then(function(neighbors) {
-            neighborsLoaded = true;
-            if (neighbors.length === 0) {
-                dropdown.innerHTML = '<div class="neighbors-error">No neighbors configured</div>';
-                return;
-            }
-            let html = '<div class="neighbors-list">';
-            neighbors.forEach(function(n) {
-                html += '<a href="' + escapeHtml(n.url) + '" class="neighbor-item">' + escapeHtml(n.name) + '</a>';
-            });
-            html += '</div>';
-            dropdown.innerHTML = html;
-        })
-        .catch(function() {
-            dropdown.innerHTML = '<div class="neighbors-error">Failed to load neighbors</div>';
-        });
-}
-
-function escapeHtml(text) {
-    const div = document.createElement('div');
-    div.textContent = text;
-    return div.innerHTML;
-}
-
-// close neighbors dropdown when clicking outside
+// close neighbors dropdown on click outside or ESC
 document.addEventListener('click', function(e) {
-    const selector = document.querySelector('.neighbors-selector');
-    const dropdown = document.getElementById('neighbors-dropdown');
-    if (!selector || !dropdown) return;
-
-    if (!selector.contains(e.target)) {
-        dropdown.style.display = 'none';
-        selector.classList.remove('open');
+    const details = document.querySelector('.neighbors-selector');
+    if (details && details.open && !details.contains(e.target)) {
+        details.open = false;
     }
 });
 
-// close neighbors dropdown on ESC
 document.addEventListener('keydown', function(e) {
     if (e.key === 'Escape') {
-        const selector = document.querySelector('.neighbors-selector');
-        const dropdown = document.getElementById('neighbors-dropdown');
-        if (selector && dropdown && dropdown.style.display !== 'none') {
-            dropdown.style.display = 'none';
-            selector.classList.remove('open');
+        const details = document.querySelector('.neighbors-selector');
+        if (details && details.open) {
+            details.open = false;
         }
     }
 });

--- a/app/web/static/style.css
+++ b/app/web/static/style.css
@@ -188,6 +188,93 @@ code {
     border: 1px solid var(--color-border);
 }
 
+/* Neighbors selector dropdown */
+.neighbors-selector {
+    position: relative;
+    display: inline-block;
+    margin-left: var(--spacing-3);
+}
+
+.hostname-badge-clickable {
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    transition: all 0.2s ease;
+    font-family: inherit;
+    margin-left: 0;
+}
+
+.hostname-badge-clickable:hover {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+}
+
+.dropdown-arrow {
+    opacity: 0.6;
+    transition: transform 0.2s ease;
+}
+
+.neighbors-selector.open .dropdown-arrow {
+    transform: rotate(180deg);
+}
+
+.neighbors-dropdown {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    min-width: 180px;
+    max-width: 300px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-lg);
+    z-index: 1000;
+    overflow: hidden;
+}
+
+.neighbors-loading,
+.neighbors-error {
+    padding: var(--spacing-sm) var(--spacing-md);
+    color: var(--color-text-muted);
+    font-size: var(--text-sm);
+    text-align: center;
+}
+
+.neighbors-error {
+    color: var(--color-error);
+}
+
+.neighbors-list {
+    max-height: 300px;
+    overflow-y: auto;
+}
+
+.neighbor-item {
+    display: block;
+    padding: var(--spacing-sm) var(--spacing-md);
+    color: var(--color-text);
+    text-decoration: none;
+    font-size: var(--text-sm);
+    transition: background-color 0.15s ease;
+    border-bottom: 1px solid var(--color-border);
+}
+
+.neighbor-item:last-child {
+    border-bottom: none;
+}
+
+.neighbor-item:hover {
+    background: var(--color-surface-hover);
+    color: var(--color-primary);
+}
+
+.neighbor-item.current {
+    background: var(--color-surface-hover);
+    font-weight: var(--font-medium);
+    color: var(--color-primary);
+}
+
 .header-controls {
     display: flex;
     gap: var(--spacing-sm);

--- a/app/web/static/style.css
+++ b/app/web/static/style.css
@@ -215,7 +215,7 @@ code {
     transition: transform 0.2s ease;
 }
 
-.neighbors-selector.open .dropdown-arrow {
+.neighbors-selector[open] .dropdown-arrow {
     transform: rotate(180deg);
 }
 

--- a/app/web/templates/base.html
+++ b/app/web/templates/base.html
@@ -19,7 +19,23 @@
                         <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
                         <path d="M12 6v6l4 2" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
                     </svg>
-                    <h1 class="logo-text">Cronn{{if .Hostname}} <span class="hostname-badge">{{.Hostname}}</span>{{end}}</h1>
+                    <h1 class="logo-text">Cronn{{if .Hostname}}
+                        {{if .NeighborsEnabled}}
+                        <div class="neighbors-selector">
+                            <button class="hostname-badge hostname-badge-clickable" onclick="toggleNeighborsDropdown(event)">
+                                {{.Hostname}}
+                                <svg class="dropdown-arrow" width="12" height="12" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                </svg>
+                            </button>
+                            <div id="neighbors-dropdown" class="neighbors-dropdown" style="display: none;">
+                                <div class="neighbors-loading">Loading...</div>
+                            </div>
+                        </div>
+                        {{else}}
+                        <span class="hostname-badge">{{.Hostname}}</span>
+                        {{end}}
+                    {{end}}</h1>
                 </div>
                 
                 <div class="header-controls">

--- a/app/web/templates/base.html
+++ b/app/web/templates/base.html
@@ -21,17 +21,20 @@
                     </svg>
                     <h1 class="logo-text">Cronn{{if .Hostname}}
                         {{if .NeighborsEnabled}}
-                        <div class="neighbors-selector">
-                            <button class="hostname-badge hostname-badge-clickable" onclick="toggleNeighborsDropdown(event)">
+                        <details class="neighbors-selector">
+                            <summary class="hostname-badge hostname-badge-clickable">
                                 {{.Hostname}}
                                 <svg class="dropdown-arrow" width="12" height="12" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                     <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                 </svg>
-                            </button>
-                            <div id="neighbors-dropdown" class="neighbors-dropdown" style="display: none;">
+                            </summary>
+                            <div class="neighbors-dropdown"
+                                 hx-get="{{url "/api/neighbors"}}"
+                                 hx-trigger="toggle once from:closest details"
+                                 hx-swap="innerHTML">
                                 <div class="neighbors-loading">Loading...</div>
                             </div>
-                        </div>
+                        </details>
                         {{else}}
                         <span class="hostname-badge">{{.Hostname}}</span>
                         {{end}}

--- a/app/web/templates/partials/neighbors.html
+++ b/app/web/templates/partials/neighbors.html
@@ -1,0 +1,15 @@
+{{define "neighbors-list"}}
+{{if .Neighbors}}
+<div class="neighbors-list">
+    {{range .Neighbors}}
+    <a href="{{.URL}}" class="neighbor-item">{{.Name}}</a>
+    {{end}}
+</div>
+{{else}}
+<div class="neighbors-error">No neighbors configured</div>
+{{end}}
+{{end}}
+
+{{define "neighbors-error"}}
+<div class="neighbors-error">{{.Error}}</div>
+{{end}}

--- a/app/web/web_integration_test.go
+++ b/app/web/web_integration_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -1106,4 +1107,277 @@ func TestServer_EventChannelStress(t *testing.T) {
 	server.jobsMu.RUnlock()
 
 	assert.GreaterOrEqual(t, jobCount, 0, "server should still be functional after stress test")
+}
+
+func TestServer_NeighborsIntegration(t *testing.T) {
+	t.Run("returns 404 when neighbors not configured", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		dbPath := filepath.Join(tmpDir, "test.db")
+		crontabFile := filepath.Join(tmpDir, "crontab")
+
+		err := os.WriteFile(crontabFile, []byte("* * * * * echo test"), 0o600)
+		require.NoError(t, err)
+
+		parser := crontab.New(crontabFile, 0, nil)
+		cfg := Config{
+			DBPath:         dbPath,
+			UpdateInterval: time.Minute,
+			Version:        "test",
+			JobsProvider:   parser,
+			NeighborsURL:   "", // not configured
+		}
+
+		server, err := New(cfg)
+		require.NoError(t, err)
+		defer server.store.Close()
+
+		// create test server with routes
+		router := server.routes()
+		ts := httptest.NewServer(router)
+		defer ts.Close()
+
+		resp, err := http.Get(ts.URL + "/api/neighbors")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+
+	t.Run("returns neighbors from HTTP source via full route", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		dbPath := filepath.Join(tmpDir, "test.db")
+		crontabFile := filepath.Join(tmpDir, "crontab")
+
+		err := os.WriteFile(crontabFile, []byte("* * * * * echo test"), 0o600)
+		require.NoError(t, err)
+
+		// create mock neighbors server
+		neighbors := []NeighborInstance{
+			{Name: "server-1", URL: "http://server1.example.com"},
+			{Name: "server-2", URL: "http://server2.example.com"},
+		}
+		mockNeighborsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(neighbors)
+		}))
+		defer mockNeighborsServer.Close()
+
+		parser := crontab.New(crontabFile, 0, nil)
+		cfg := Config{
+			DBPath:         dbPath,
+			UpdateInterval: time.Minute,
+			Version:        "test",
+			JobsProvider:   parser,
+			NeighborsURL:   mockNeighborsServer.URL,
+		}
+
+		server, err := New(cfg)
+		require.NoError(t, err)
+		defer server.store.Close()
+
+		router := server.routes()
+		ts := httptest.NewServer(router)
+		defer ts.Close()
+
+		resp, err := http.Get(ts.URL + "/api/neighbors")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+		var result []NeighborInstance
+		err = json.NewDecoder(resp.Body).Decode(&result)
+		require.NoError(t, err)
+		assert.Equal(t, neighbors, result)
+	})
+
+	t.Run("returns neighbors from file source via full route", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		dbPath := filepath.Join(tmpDir, "test.db")
+		crontabFile := filepath.Join(tmpDir, "crontab")
+		neighborsFile := filepath.Join(tmpDir, "neighbors.json")
+
+		err := os.WriteFile(crontabFile, []byte("* * * * * echo test"), 0o600)
+		require.NoError(t, err)
+
+		neighbors := []NeighborInstance{
+			{Name: "file-server-1", URL: "http://file1.example.com"},
+			{Name: "file-server-2", URL: "http://file2.example.com"},
+		}
+		neighborsJSON, err := json.Marshal(neighbors)
+		require.NoError(t, err)
+		err = os.WriteFile(neighborsFile, neighborsJSON, 0o600)
+		require.NoError(t, err)
+
+		parser := crontab.New(crontabFile, 0, nil)
+		cfg := Config{
+			DBPath:         dbPath,
+			UpdateInterval: time.Minute,
+			Version:        "test",
+			JobsProvider:   parser,
+			NeighborsURL:   "file://" + neighborsFile,
+		}
+
+		server, err := New(cfg)
+		require.NoError(t, err)
+		defer server.store.Close()
+
+		router := server.routes()
+		ts := httptest.NewServer(router)
+		defer ts.Close()
+
+		resp, err := http.Get(ts.URL + "/api/neighbors")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var result []NeighborInstance
+		err = json.NewDecoder(resp.Body).Decode(&result)
+		require.NoError(t, err)
+		assert.Equal(t, neighbors, result)
+	})
+
+	t.Run("caches neighbors with TTL", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		dbPath := filepath.Join(tmpDir, "test.db")
+		crontabFile := filepath.Join(tmpDir, "crontab")
+
+		err := os.WriteFile(crontabFile, []byte("* * * * * echo test"), 0o600)
+		require.NoError(t, err)
+
+		// track how many times mock server is called
+		var callCount int
+		var mu sync.Mutex
+		mockNeighborsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			callCount++
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]NeighborInstance{{Name: "server", URL: "http://test.com"}})
+		}))
+		defer mockNeighborsServer.Close()
+
+		parser := crontab.New(crontabFile, 0, nil)
+		cfg := Config{
+			DBPath:         dbPath,
+			UpdateInterval: time.Minute,
+			Version:        "test",
+			JobsProvider:   parser,
+			NeighborsURL:   mockNeighborsServer.URL,
+		}
+
+		server, err := New(cfg)
+		require.NoError(t, err)
+		defer server.store.Close()
+
+		router := server.routes()
+		ts := httptest.NewServer(router)
+		defer ts.Close()
+
+		// first request - should hit the mock server
+		resp, err := http.Get(ts.URL + "/api/neighbors")
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// second request - should use cache (within 5 min TTL)
+		resp, err = http.Get(ts.URL + "/api/neighbors")
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// third request - should still use cache
+		resp, err = http.Get(ts.URL + "/api/neighbors")
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// verify mock server was only called once due to caching
+		mu.Lock()
+		assert.Equal(t, 1, callCount, "mock server should be called only once due to caching")
+		mu.Unlock()
+	})
+
+	t.Run("dashboard includes NeighborsEnabled when configured", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		dbPath := filepath.Join(tmpDir, "test.db")
+		crontabFile := filepath.Join(tmpDir, "crontab")
+
+		err := os.WriteFile(crontabFile, []byte("* * * * * echo test"), 0o600)
+		require.NoError(t, err)
+
+		parser := crontab.New(crontabFile, 0, nil)
+		cfg := Config{
+			DBPath:         dbPath,
+			UpdateInterval: time.Minute,
+			Version:        "test",
+			JobsProvider:   parser,
+			Hostname:       "test-host",
+			NeighborsURL:   "http://example.com/neighbors", // configured
+		}
+
+		server, err := New(cfg)
+		require.NoError(t, err)
+		defer server.store.Close()
+
+		router := server.routes()
+		ts := httptest.NewServer(router)
+		defer ts.Close()
+
+		resp, err := http.Get(ts.URL + "/")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// read body and check for neighbors-selector class (only present when NeighborsEnabled)
+		buf := make([]byte, 64*1024)
+		n, _ := resp.Body.Read(buf)
+		body := string(buf[:n])
+
+		assert.Contains(t, body, "neighbors-selector", "dashboard should contain neighbors-selector when configured")
+		assert.Contains(t, body, "toggleNeighborsDropdown", "dashboard should contain dropdown toggle function")
+	})
+
+	t.Run("dashboard excludes neighbors selector when not configured", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		dbPath := filepath.Join(tmpDir, "test.db")
+		crontabFile := filepath.Join(tmpDir, "crontab")
+
+		err := os.WriteFile(crontabFile, []byte("* * * * * echo test"), 0o600)
+		require.NoError(t, err)
+
+		parser := crontab.New(crontabFile, 0, nil)
+		cfg := Config{
+			DBPath:         dbPath,
+			UpdateInterval: time.Minute,
+			Version:        "test",
+			JobsProvider:   parser,
+			Hostname:       "test-host",
+			NeighborsURL:   "", // not configured
+		}
+
+		server, err := New(cfg)
+		require.NoError(t, err)
+		defer server.store.Close()
+
+		router := server.routes()
+		ts := httptest.NewServer(router)
+		defer ts.Close()
+
+		resp, err := http.Get(ts.URL + "/")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		buf := make([]byte, 64*1024)
+		n, _ := resp.Body.Read(buf)
+		body := string(buf[:n])
+
+		assert.NotContains(t, body, "neighbors-selector", "dashboard should not contain neighbors-selector when not configured")
+		assert.NotContains(t, body, "toggleNeighborsDropdown", "dashboard should not contain dropdown toggle when not configured")
+	})
 }


### PR DESCRIPTION
## Summary
- adds optional server selector dropdown to hostname badge in web UI
- when configured via `--web.neighbors-url`, clicking the hostname opens a dropdown with neighboring cronn instances
- supports both HTTP/HTTPS URLs and `file://` paths for local JSON files
- includes 5-minute caching to reduce API calls

## Changes
- new CLI flag `--web.neighbors-url` / `CRONN_NEIGHBORS_URL`
- `/api/neighbors` endpoint proxies neighbor data (avoids CORS)
- dropdown UI with lazy loading on first click
- unit tests in `neighbors_test.go`, integration tests in `web_integration_test.go`

## Configuration example
```bash
# HTTP source
cronn --web.enabled --web.neighbors-url="https://config.example.com/neighbors.json"

# Local file
cronn --web.enabled --web.neighbors-url="file:///etc/cronn/neighbors.json"
```

JSON format:
```json
[
  {"name": "prod-server-1", "url": "https://prod1.example.com:8080"},
  {"name": "staging", "url": "https://staging.example.com:8080"}
]
```