### PR TITLE
Add job enable/disable toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ coverage.html
 bin/
 dist/
 .idea/
+.zed/
 site/docs/index.md
 site/site/
 site/.venv/

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ coverage.html
 bin/
 dist/
 .idea/
-.zed/
 site/docs/index.md
 site/site/
 site/.venv/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Functions return concrete `*SQLiteStore` while accepting `Persistence` interface
 - **Out-of-band updates**: `hx-swap-oob="innerHTML"` for updating multiple elements in single response
 - **Auto-refresh polling**: `hx-trigger="load, every 5s"` for JavaScript-free real-time updates
 - **Response coordination**: `HX-Refresh: true` header triggers full page refresh when needed
-- **Event coordination**: Custom events like `refresh-jobs` coordinate updates between components
+- **Event coordination**: Custom events like `refresh-jobs` coordinate updates between components (used by toggle, sort, filter)
 - **Lazy-load dropdowns**: Native `<details>/<summary>` with `hx-trigger="toggle once"` for dropdowns that fetch content on first open (used in neighbors selector)
 
 ### Event-Driven Architecture
@@ -113,6 +113,15 @@ svc := service.New(..., service.WithManualTrigger(manualJobChan))
 // web UI sends job ID to channel
 manualJobChan <- jobID
 ```
+
+## Job Enable/Disable Toggle
+
+### Toggle Mechanism
+- Web UI toggle button (`POST /api/jobs/{id}/toggle`) flips `job.Enabled` in memory
+- State persisted immediately via `persistJobs()` after toggle
+- HTMX `HX-Trigger: refresh-jobs` header triggers UI refresh after toggle
+- Disabled jobs shown with `job-disabled` CSS class (visual dimming in both card and list views)
+- Toggle button uses `btn-toggle` / `btn-disabled-state` CSS classes for visual state feedback
 
 ## Type-Safe Enum Pattern
 

--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ GET /api/v1/jobs/{id}/history
 **Toggle Job** - Enable or disable a job:
 
 ```
-POST /api/jobs/{id}/toggle
+POST /api/v1/jobs/{id}/toggle
 ```
 
 **Execution Logs** - Get details and output for a specific execution:

--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ Cronn includes a modern web dashboard for monitoring and managing cron jobs. The
   - Visual indicators for customized manual runs
 - **Multiple view modes**: Card view and compact list view with toggle button
 - **Sorting options**: Sort jobs by original order, last run time, or next run time
+- **Job enable/disable toggle**: Disable individual jobs from the dashboard without editing config files
 - **Status filtering**: Filter jobs by status (all, running, success, failed)
 - **Light, dark, and auto themes** with automatic system preference detection
 - **Job statistics bar** showing total jobs, currently running jobs, and next execution time
@@ -450,6 +451,12 @@ GET /api/v1/status
 
 ```
 GET /api/v1/jobs/{id}/history
+```
+
+**Toggle Job** - Enable or disable a job:
+
+```
+POST /api/jobs/{id}/toggle
 ```
 
 **Execution Logs** - Get details and output for a specific execution:

--- a/app/main.go
+++ b/app/main.go
@@ -158,7 +158,6 @@ func main() {
 
 	// create manual trigger channel if web UI is enabled
 	var manualTrigger chan service.ManualJobRequest
-
 	if opts.Web.Enabled {
 		manualTrigger = make(chan service.ManualJobRequest, 100)
 	} else {
@@ -198,7 +197,7 @@ func main() {
 			log.Printf("[ERROR] failed to create web server: %v", err)
 			os.Exit(1)
 		}
-		eventHandler = webServer  // web.Server implements JobEventHandler
+		eventHandler = webServer // web.Server implements JobEventHandler
 		isJobDisabled = webServer.IsJobDisabled
 
 		// start web server in background

--- a/app/main.go
+++ b/app/main.go
@@ -158,8 +158,11 @@ func main() {
 
 	// create manual trigger channel if web UI is enabled
 	var manualTrigger chan service.ManualJobRequest
+	var disableToggle chan string
+
 	if opts.Web.Enabled {
 		manualTrigger = make(chan service.ManualJobRequest, 100)
+		disableToggle = make(chan string, 100)
 	} else {
 		// disable execution history if web is not enabled (no UI to view it)
 		opts.Log.ExecMaxLines = 0
@@ -181,6 +184,7 @@ func main() {
 			Hostname:           hostname,
 			Version:            revision,
 			ManualTrigger:      manualTrigger,
+			DisableToggle:      disableToggle,
 			JobsProvider:       crontabParser,
 			PasswordHash:       opts.Web.PasswordHash,
 			LoginTTL:           opts.Web.LoginTTL,
@@ -226,6 +230,7 @@ func main() {
 		NotifyTimeout:     opts.Notify.TimeOut,
 		JobEventHandler:   eventHandler,
 		ManualTrigger:     manualTrigger,
+		DisableToggle:     disableToggle,
 		AltTemplate:       opts.AltTemplate,
 	}
 

--- a/app/main.go
+++ b/app/main.go
@@ -158,11 +158,9 @@ func main() {
 
 	// create manual trigger channel if web UI is enabled
 	var manualTrigger chan service.ManualJobRequest
-	var disableToggle chan string
 
 	if opts.Web.Enabled {
 		manualTrigger = make(chan service.ManualJobRequest, 100)
-		disableToggle = make(chan string, 100)
 	} else {
 		// disable execution history if web is not enabled (no UI to view it)
 		opts.Log.ExecMaxLines = 0
@@ -171,6 +169,7 @@ func main() {
 
 	// initialize web server if enabled
 	var eventHandler service.JobEventHandler
+	var isJobDisabled func(string) bool
 	if opts.Web.Enabled {
 		baseURL := validateBaseURL(opts.Web.BaseURL)
 
@@ -184,7 +183,6 @@ func main() {
 			Hostname:           hostname,
 			Version:            revision,
 			ManualTrigger:      manualTrigger,
-			DisableToggle:      disableToggle,
 			JobsProvider:       crontabParser,
 			PasswordHash:       opts.Web.PasswordHash,
 			LoginTTL:           opts.Web.LoginTTL,
@@ -200,7 +198,8 @@ func main() {
 			log.Printf("[ERROR] failed to create web server: %v", err)
 			os.Exit(1)
 		}
-		eventHandler = webServer // web.Server implements JobEventHandler
+		eventHandler = webServer  // web.Server implements JobEventHandler
+		isJobDisabled = webServer.IsJobDisabled
 
 		// start web server in background
 		go func() {
@@ -230,7 +229,7 @@ func main() {
 		NotifyTimeout:     opts.Notify.TimeOut,
 		JobEventHandler:   eventHandler,
 		ManualTrigger:     manualTrigger,
-		DisableToggle:     disableToggle,
+		IsJobDisabled:     isJobDisabled,
 		AltTemplate:       opts.AltTemplate,
 	}
 

--- a/app/service/service.go
+++ b/app/service/service.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
+	"sync"
 	"time"
 
 	log "github.com/go-pkgz/lgr"
@@ -63,7 +64,11 @@ type Scheduler struct {
 	NotifyTimeout   time.Duration
 	JobEventHandler JobEventHandler       // handler for job execution events
 	ManualTrigger   chan ManualJobRequest // channel for manual job triggers
+	DisableToggle   chan string           // channel for job enable/disable toggle (receives job ID)
 	AltTemplate     bool                  // use alternative template format [[.YYYYMMDD]]
+
+	disabledJobs   map[string]bool // set of disabled job IDs
+	disabledJobsMu sync.RWMutex
 }
 
 // ManualJobRequest represents a request to manually trigger a job
@@ -153,6 +158,12 @@ func (s *Scheduler) Do(ctx context.Context) {
 	// start manual trigger listener if channel is provided
 	if s.ManualTrigger != nil {
 		go s.listenForManualTriggers(ctx)
+	}
+
+	// start disable toggle listener if channel is provided
+	if s.DisableToggle != nil {
+		s.disabledJobs = make(map[string]bool)
+		go s.listenForDisableToggle(ctx)
 	}
 
 	fileMissing := false
@@ -317,6 +328,15 @@ func (s *Scheduler) jobFuncWithEditedCommand(ctx context.Context, r crontab.JobS
 
 func (s *Scheduler) jobFuncWithTime(ctx context.Context, r crontab.JobSpec, sched Schedule, customTime *time.Time) cron.FuncJob {
 	return func() {
+		// check if job is disabled via web UI
+		s.disabledJobsMu.RLock()
+		disabled := s.disabledJobs[s.jobIDFromCommand(r.Command)]
+		s.disabledJobsMu.RUnlock()
+		if disabled {
+			log.Printf("[INFO] job disabled, skipping: %s", s.jobDescription(r))
+			return
+		}
+
 		jobDesc := s.jobDescription(r)
 		jobRepeater := s.getJobRepeater(r.Repeater)
 
@@ -455,6 +475,30 @@ func (s *Scheduler) reload(ctx context.Context) {
 			if err = s.loadFromFileParser(ctx); err != nil {
 				log.Printf("[WARN] failed to update jobs, %v", err)
 			}
+		}
+	}
+}
+
+// listenForDisableToggle listens for job disable/enable toggle events
+func (s *Scheduler) listenForDisableToggle(ctx context.Context) {
+	log.Printf("[INFO] disable toggle listener started")
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case jobID, ok := <-s.DisableToggle:
+			if !ok {
+				return
+			}
+			s.disabledJobsMu.Lock()
+			if s.disabledJobs[jobID] {
+				delete(s.disabledJobs, jobID)
+				log.Printf("[INFO] job %s enabled", jobID)
+			} else {
+				s.disabledJobs[jobID] = true
+				log.Printf("[INFO] job %s disabled", jobID)
+			}
+			s.disabledJobsMu.Unlock()
 		}
 	}
 }

--- a/app/service/service.go
+++ b/app/service/service.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
-	"sync"
 	"time"
 
 	log "github.com/go-pkgz/lgr"
@@ -63,12 +62,9 @@ type Scheduler struct {
 	Stdout          io.Writer
 	NotifyTimeout   time.Duration
 	JobEventHandler JobEventHandler       // handler for job execution events
-	ManualTrigger   chan ManualJobRequest // channel for manual job triggers
-	DisableToggle   chan string           // channel for job enable/disable toggle (receives job ID)
-	AltTemplate     bool                  // use alternative template format [[.YYYYMMDD]]
-
-	disabledJobs   map[string]bool // set of disabled job IDs
-	disabledJobsMu sync.RWMutex
+	ManualTrigger  chan ManualJobRequest      // channel for manual job triggers
+	IsJobDisabled  func(jobID string) bool  // callback to check if a job is disabled via web UI
+	AltTemplate    bool                     // use alternative template format [[.YYYYMMDD]]
 }
 
 // ManualJobRequest represents a request to manually trigger a job
@@ -158,12 +154,6 @@ func (s *Scheduler) Do(ctx context.Context) {
 	// start manual trigger listener if channel is provided
 	if s.ManualTrigger != nil {
 		go s.listenForManualTriggers(ctx)
-	}
-
-	// start disable toggle listener if channel is provided
-	if s.DisableToggle != nil {
-		s.disabledJobs = make(map[string]bool)
-		go s.listenForDisableToggle(ctx)
 	}
 
 	fileMissing := false
@@ -329,10 +319,7 @@ func (s *Scheduler) jobFuncWithEditedCommand(ctx context.Context, r crontab.JobS
 func (s *Scheduler) jobFuncWithTime(ctx context.Context, r crontab.JobSpec, sched Schedule, customTime *time.Time) cron.FuncJob {
 	return func() {
 		// check if job is disabled via web UI
-		s.disabledJobsMu.RLock()
-		disabled := s.disabledJobs[s.jobIDFromCommand(r.Command)]
-		s.disabledJobsMu.RUnlock()
-		if disabled {
+		if s.IsJobDisabled != nil && s.IsJobDisabled(s.jobIDFromCommand(r.Command)) {
 			log.Printf("[INFO] job disabled, skipping: %s", s.jobDescription(r))
 			return
 		}
@@ -475,30 +462,6 @@ func (s *Scheduler) reload(ctx context.Context) {
 			if err = s.loadFromFileParser(ctx); err != nil {
 				log.Printf("[WARN] failed to update jobs, %v", err)
 			}
-		}
-	}
-}
-
-// listenForDisableToggle listens for job disable/enable toggle events
-func (s *Scheduler) listenForDisableToggle(ctx context.Context) {
-	log.Printf("[INFO] disable toggle listener started")
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case jobID, ok := <-s.DisableToggle:
-			if !ok {
-				return
-			}
-			s.disabledJobsMu.Lock()
-			if s.disabledJobs[jobID] {
-				delete(s.disabledJobs, jobID)
-				log.Printf("[INFO] job %s enabled", jobID)
-			} else {
-				s.disabledJobs[jobID] = true
-				log.Printf("[INFO] job %s disabled", jobID)
-			}
-			s.disabledJobsMu.Unlock()
 		}
 	}
 }

--- a/app/service/service_test.go
+++ b/app/service/service_test.go
@@ -2000,82 +2000,40 @@ func TestScheduler_disableToggle(t *testing.T) {
 
 	t.Run("disabled job is skipped", func(t *testing.T) {
 		wr := &safeWriter{}
-		disableToggle := make(chan string, 10)
 		svc := Scheduler{
 			NotifyMaxLogLines: 10, Stdout: wr, Resumer: resmr,
 			Repeater: repeater.New(&strategy.Once{}), DeDup: NewDeDup(true),
-			DisableToggle: disableToggle,
+			IsJobDisabled: func(string) bool { return true },
 		}
 
-		ctx := t.Context()
-		svc.disabledJobs = make(map[string]bool)
-		go svc.listenForDisableToggle(ctx)
-
 		jobSpec := crontab.JobSpec{Spec: "@startup", Command: "echo disabled-test"}
-		jobID := svc.jobIDFromCommand(jobSpec.Command)
-
-		// disable the job
-		disableToggle <- jobID
-		require.Eventually(t, func() bool {
-			svc.disabledJobsMu.RLock()
-			defer svc.disabledJobsMu.RUnlock()
-			return svc.disabledJobs[jobID]
-		}, time.Second, 10*time.Millisecond)
-
-		// run the job — should be skipped
-		svc.jobFunc(ctx, jobSpec, scheduleMock).Run()
+		svc.jobFunc(t.Context(), jobSpec, scheduleMock).Run()
 		assert.Empty(t, wr.String(), "disabled job should not produce output")
 	})
 
-	t.Run("re-enabled job executes", func(t *testing.T) {
+	t.Run("enabled job executes", func(t *testing.T) {
 		wr := &safeWriter{}
-		disableToggle := make(chan string, 10)
 		svc := Scheduler{
 			NotifyMaxLogLines: 10, Stdout: wr, Resumer: resmr,
 			Repeater: repeater.New(&strategy.Once{}), DeDup: NewDeDup(true),
-			DisableToggle: disableToggle,
+			IsJobDisabled: func(string) bool { return false },
 		}
 
-		ctx := t.Context()
-		svc.disabledJobs = make(map[string]bool)
-		go svc.listenForDisableToggle(ctx)
-
-		jobSpec := crontab.JobSpec{Spec: "@startup", Command: "echo reenable-test"}
-		jobID := svc.jobIDFromCommand(jobSpec.Command)
-
-		// disable then re-enable
-		disableToggle <- jobID
-		disableToggle <- jobID
-		require.Eventually(t, func() bool {
-			svc.disabledJobsMu.RLock()
-			defer svc.disabledJobsMu.RUnlock()
-			return !svc.disabledJobs[jobID]
-		}, time.Second, 10*time.Millisecond)
-
-		// run the job — should execute
-		svc.jobFunc(ctx, jobSpec, scheduleMock).Run()
-		assert.Contains(t, wr.String(), "reenable-test")
+		jobSpec := crontab.JobSpec{Spec: "@startup", Command: "echo enabled-test"}
+		svc.jobFunc(t.Context(), jobSpec, scheduleMock).Run()
+		assert.Contains(t, wr.String(), "enabled-test")
 	})
 
-	t.Run("listener stops on context cancel", func(t *testing.T) {
-		disableToggle := make(chan string, 10)
-		svc := Scheduler{DisableToggle: disableToggle}
-		svc.disabledJobs = make(map[string]bool)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		done := make(chan struct{})
-		go func() {
-			svc.listenForDisableToggle(ctx)
-			close(done)
-		}()
-
-		cancel()
-		select {
-		case <-done:
-			// success
-		case <-time.After(time.Second):
-			t.Fatal("listener should stop on context cancel")
+	t.Run("nil callback allows execution", func(t *testing.T) {
+		wr := &safeWriter{}
+		svc := Scheduler{
+			NotifyMaxLogLines: 10, Stdout: wr, Resumer: resmr,
+			Repeater: repeater.New(&strategy.Once{}), DeDup: NewDeDup(true),
 		}
+
+		jobSpec := crontab.JobSpec{Spec: "@startup", Command: "echo nil-callback-test"}
+		svc.jobFunc(t.Context(), jobSpec, scheduleMock).Run()
+		assert.Contains(t, wr.String(), "nil-callback-test")
 	})
 }
 

--- a/app/service/service_test.go
+++ b/app/service/service_test.go
@@ -1987,6 +1987,100 @@ func TestScheduler_resumeInterrupted(t *testing.T) {
 	})
 }
 
+func TestScheduler_disableToggle(t *testing.T) {
+	resmr := &mocks.ResumerMock{
+		OnStartFunc:  func(cmd string) (string, error) { return "resume.file", nil },
+		OnFinishFunc: func(fname string) error { return nil },
+	}
+	scheduleMock := &mocks.ScheduleMock{
+		NextFunc: func(timeMoqParam time.Time) time.Time {
+			return time.Date(2020, 7, 21, 16, 30, 0, 0, time.UTC)
+		},
+	}
+
+	t.Run("disabled job is skipped", func(t *testing.T) {
+		wr := &safeWriter{}
+		disableToggle := make(chan string, 10)
+		svc := Scheduler{
+			NotifyMaxLogLines: 10, Stdout: wr, Resumer: resmr,
+			Repeater: repeater.New(&strategy.Once{}), DeDup: NewDeDup(true),
+			DisableToggle: disableToggle,
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		svc.disabledJobs = make(map[string]bool)
+		go svc.listenForDisableToggle(ctx)
+
+		jobSpec := crontab.JobSpec{Spec: "@startup", Command: "echo disabled-test"}
+		jobID := svc.jobIDFromCommand(jobSpec.Command)
+
+		// disable the job
+		disableToggle <- jobID
+		require.Eventually(t, func() bool {
+			svc.disabledJobsMu.RLock()
+			defer svc.disabledJobsMu.RUnlock()
+			return svc.disabledJobs[jobID]
+		}, time.Second, 10*time.Millisecond)
+
+		// run the job — should be skipped
+		svc.jobFunc(ctx, jobSpec, scheduleMock).Run()
+		assert.Empty(t, wr.String(), "disabled job should not produce output")
+	})
+
+	t.Run("re-enabled job executes", func(t *testing.T) {
+		wr := &safeWriter{}
+		disableToggle := make(chan string, 10)
+		svc := Scheduler{
+			NotifyMaxLogLines: 10, Stdout: wr, Resumer: resmr,
+			Repeater: repeater.New(&strategy.Once{}), DeDup: NewDeDup(true),
+			DisableToggle: disableToggle,
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		svc.disabledJobs = make(map[string]bool)
+		go svc.listenForDisableToggle(ctx)
+
+		jobSpec := crontab.JobSpec{Spec: "@startup", Command: "echo reenable-test"}
+		jobID := svc.jobIDFromCommand(jobSpec.Command)
+
+		// disable then re-enable
+		disableToggle <- jobID
+		disableToggle <- jobID
+		require.Eventually(t, func() bool {
+			svc.disabledJobsMu.RLock()
+			defer svc.disabledJobsMu.RUnlock()
+			return !svc.disabledJobs[jobID]
+		}, time.Second, 10*time.Millisecond)
+
+		// run the job — should execute
+		svc.jobFunc(ctx, jobSpec, scheduleMock).Run()
+		assert.Contains(t, wr.String(), "reenable-test")
+	})
+
+	t.Run("listener stops on context cancel", func(t *testing.T) {
+		disableToggle := make(chan string, 10)
+		svc := Scheduler{DisableToggle: disableToggle}
+		svc.disabledJobs = make(map[string]bool)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan struct{})
+		go func() {
+			svc.listenForDisableToggle(ctx)
+			close(done)
+		}()
+
+		cancel()
+		select {
+		case <-done:
+			// success
+		case <-time.After(time.Second):
+			t.Fatal("listener should stop on context cancel")
+		}
+	})
+}
+
 // safeWriter wraps bytes.Buffer with mutex for thread-safe concurrent writes
 type safeWriter struct {
 	buf bytes.Buffer

--- a/app/service/service_test.go
+++ b/app/service/service_test.go
@@ -2007,8 +2007,7 @@ func TestScheduler_disableToggle(t *testing.T) {
 			DisableToggle: disableToggle,
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 		svc.disabledJobs = make(map[string]bool)
 		go svc.listenForDisableToggle(ctx)
 
@@ -2037,8 +2036,7 @@ func TestScheduler_disableToggle(t *testing.T) {
 			DisableToggle: disableToggle,
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 		svc.disabledJobs = make(map[string]bool)
 		go svc.listenForDisableToggle(ctx)
 

--- a/app/web/api.go
+++ b/app/web/api.go
@@ -101,7 +101,9 @@ func (s *Server) handleAPIStatus(w http.ResponseWriter, _ *http.Request) {
 	allJobs := make([]persistence.JobInfo, 0, len(s.jobs))
 	for _, job := range s.jobs {
 		jobCopy := job
-		s.updateNextRun(&jobCopy)
+		if jobCopy.Enabled {
+			s.updateNextRun(&jobCopy)
+		}
 		allJobs = append(allJobs, jobCopy)
 	}
 	s.jobsMu.RUnlock()
@@ -156,8 +158,10 @@ func (s *Server) handleAPIJobHistory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// update next run time
-	s.updateNextRun(&job)
+	// update next run time for enabled jobs only
+	if job.Enabled {
+		s.updateNextRun(&job)
+	}
 
 	// get execution history from database
 	executions, err := s.store.GetExecutions(jobID, 50)

--- a/app/web/handlers.go
+++ b/app/web/handlers.go
@@ -540,6 +540,31 @@ func (s *Server) handleRunJob(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// handleToggleJob toggles the enabled state of a job
+func (s *Server) handleToggleJob(w http.ResponseWriter, r *http.Request) {
+	jobID := r.PathValue("id")
+	if jobID == "" {
+		http.Error(w, "Job ID required", http.StatusBadRequest)
+		return
+	}
+
+	s.jobsMu.Lock()
+	job, exists := s.jobs[jobID]
+	if !exists {
+		s.jobsMu.Unlock()
+		http.Error(w, "Job not found", http.StatusNotFound)
+		return
+	}
+	job.Enabled = !job.Enabled
+	job.UpdatedAt = time.Now()
+	s.jobs[jobID] = job
+	s.jobsMu.Unlock()
+
+	s.persistJobs()
+	w.Header().Set("HX-Trigger", "refresh-jobs")
+	w.WriteHeader(http.StatusOK)
+}
+
 // handleJobModal handles job details modal requests
 func (s *Server) handleJobModal(w http.ResponseWriter, r *http.Request) {
 	jobID := r.PathValue("id")

--- a/app/web/handlers.go
+++ b/app/web/handlers.go
@@ -43,9 +43,11 @@ func (s *Server) getJobsWithStats(sortMode enums.SortMode, filterMode enums.Filt
 
 	// first collect all jobs and calculate stats
 	for _, job := range s.jobs {
-		// work with a copy, recalculate next run times
+		// work with a copy, recalculate next run times for enabled jobs only
 		jobCopy := job
-		s.updateNextRun(&jobCopy)
+		if jobCopy.Enabled {
+			s.updateNextRun(&jobCopy)
+		}
 		allJobs = append(allJobs, jobCopy)
 
 		// count running jobs

--- a/app/web/handlers.go
+++ b/app/web/handlers.go
@@ -562,10 +562,6 @@ func (s *Server) handleToggleJob(w http.ResponseWriter, r *http.Request) {
 	s.jobs[jobID] = job
 	s.jobsMu.Unlock()
 
-	if s.disableToggle != nil {
-		s.disableToggle <- jobID
-	}
-
 	s.persistJobs()
 	w.Header().Set("HX-Trigger", "refresh-jobs")
 	w.WriteHeader(http.StatusOK)

--- a/app/web/handlers.go
+++ b/app/web/handlers.go
@@ -560,6 +560,10 @@ func (s *Server) handleToggleJob(w http.ResponseWriter, r *http.Request) {
 	s.jobs[jobID] = job
 	s.jobsMu.Unlock()
 
+	if s.disableToggle != nil {
+		s.disableToggle <- jobID
+	}
+
 	s.persistJobs()
 	w.Header().Set("HX-Trigger", "refresh-jobs")
 	w.WriteHeader(http.StatusOK)

--- a/app/web/handlers.go
+++ b/app/web/handlers.go
@@ -423,7 +423,9 @@ func (s *Server) handleSortModeChange(w http.ResponseWriter, r *http.Request) {
 	for _, job := range s.jobs {
 		// work with a copy, recalculate next run times
 		jobCopy := job
-		s.updateNextRun(&jobCopy)
+		if jobCopy.Enabled {
+			s.updateNextRun(&jobCopy)
+		}
 		jobs = append(jobs, jobCopy)
 	}
 	s.jobsMu.RUnlock()
@@ -586,7 +588,9 @@ func (s *Server) handleJobModal(w http.ResponseWriter, r *http.Request) {
 
 	// create a copy and update next run time
 	jobCopy := job
-	s.updateNextRun(&jobCopy)
+	if jobCopy.Enabled {
+		s.updateNextRun(&jobCopy)
+	}
 
 	s.render(w, "partials/jobs.html", "job-modal", jobCopy)
 }

--- a/app/web/handlers.go
+++ b/app/web/handlers.go
@@ -53,8 +53,8 @@ func (s *Server) getJobsWithStats(sortMode enums.SortMode, filterMode enums.Filt
 			runningCount++
 		}
 
-		// find nearest next run
-		if !jobCopy.NextRun.IsZero() {
+		// find nearest next run (skip disabled jobs)
+		if jobCopy.Enabled && !jobCopy.NextRun.IsZero() {
 			if nearestNextRun == nil || jobCopy.NextRun.Before(*nearestNextRun) {
 				nearestNextRun = &jobCopy.NextRun
 			}

--- a/app/web/handlers_test.go
+++ b/app/web/handlers_test.go
@@ -1445,9 +1445,6 @@ func TestServer_handleToggleJob(t *testing.T) {
 	server.jobs[testJob.ID] = testJob
 	server.jobsMu.Unlock()
 
-	disableToggle := make(chan string, 10)
-	server.disableToggle = disableToggle
-
 	t.Run("toggle enabled to disabled", func(t *testing.T) {
 		req := httptest.NewRequest("POST", "/api/jobs/test-toggle-id/toggle", http.NoBody)
 		req.SetPathValue("id", "test-toggle-id")
@@ -1461,14 +1458,6 @@ func TestServer_handleToggleJob(t *testing.T) {
 		server.jobsMu.RLock()
 		assert.False(t, server.jobs["test-toggle-id"].Enabled)
 		server.jobsMu.RUnlock()
-
-		// verify channel received job ID
-		select {
-		case id := <-disableToggle:
-			assert.Equal(t, "test-toggle-id", id)
-		case <-time.After(time.Second):
-			t.Fatal("expected job ID on disableToggle channel")
-		}
 	})
 
 	t.Run("toggle disabled to enabled", func(t *testing.T) {
@@ -1484,14 +1473,6 @@ func TestServer_handleToggleJob(t *testing.T) {
 		server.jobsMu.RLock()
 		assert.True(t, server.jobs["test-toggle-id"].Enabled)
 		server.jobsMu.RUnlock()
-
-		// verify channel received job ID
-		select {
-		case id := <-disableToggle:
-			assert.Equal(t, "test-toggle-id", id)
-		case <-time.After(time.Second):
-			t.Fatal("expected job ID on disableToggle channel")
-		}
 	})
 
 	t.Run("job not found", func(t *testing.T) {

--- a/app/web/handlers_test.go
+++ b/app/web/handlers_test.go
@@ -699,11 +699,11 @@ func TestServer_getJobsWithStats_WithFilter(t *testing.T) {
 	// add test jobs with different statuses
 	now := time.Now()
 	server.jobs = map[string]persistence.JobInfo{
-		"1": {ID: "1", Command: "running1", IsRunning: true, LastStatus: enums.JobStatusRunning, NextRun: now.Add(time.Hour)},
-		"2": {ID: "2", Command: "success1", IsRunning: false, LastStatus: enums.JobStatusSuccess, NextRun: now.Add(2 * time.Hour)},
-		"3": {ID: "3", Command: "failed1", IsRunning: false, LastStatus: enums.JobStatusFailed, NextRun: now.Add(3 * time.Hour)},
-		"4": {ID: "4", Command: "success2", IsRunning: false, LastStatus: enums.JobStatusSuccess, NextRun: now.Add(4 * time.Hour)},
-		"5": {ID: "5", Command: "running2", IsRunning: true, LastStatus: enums.JobStatusRunning, NextRun: now.Add(30 * time.Minute)},
+		"1": {ID: "1", Command: "running1", IsRunning: true, LastStatus: enums.JobStatusRunning, NextRun: now.Add(time.Hour), Enabled: true},
+		"2": {ID: "2", Command: "success1", IsRunning: false, LastStatus: enums.JobStatusSuccess, NextRun: now.Add(2 * time.Hour), Enabled: true},
+		"3": {ID: "3", Command: "failed1", IsRunning: false, LastStatus: enums.JobStatusFailed, NextRun: now.Add(3 * time.Hour), Enabled: true},
+		"4": {ID: "4", Command: "success2", IsRunning: false, LastStatus: enums.JobStatusSuccess, NextRun: now.Add(4 * time.Hour), Enabled: true},
+		"5": {ID: "5", Command: "running2", IsRunning: true, LastStatus: enums.JobStatusRunning, NextRun: now.Add(30 * time.Minute), Enabled: true},
 	}
 
 	t.Run("filter all", func(t *testing.T) {

--- a/app/web/handlers_test.go
+++ b/app/web/handlers_test.go
@@ -1416,3 +1416,114 @@ func TestServer_handleExecutionLogs(t *testing.T) {
 		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 	})
 }
+
+func TestServer_handleToggleJob(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	cfg := Config{
+		DBPath:         dbPath,
+		UpdateInterval: time.Minute,
+		Version:        "test",
+		JobsProvider:   createTestProvider(t, tmpDir),
+	}
+
+	server, err := New(cfg)
+	require.NoError(t, err)
+	defer server.store.Close()
+
+	// add test job
+	testJob := persistence.JobInfo{
+		ID:         "test-toggle-id",
+		Command:    "echo toggle",
+		Schedule:   "* * * * *",
+		Enabled:    true,
+		IsRunning:  false,
+		LastStatus: enums.JobStatusIdle,
+	}
+	server.jobsMu.Lock()
+	server.jobs[testJob.ID] = testJob
+	server.jobsMu.Unlock()
+
+	t.Run("toggle enabled to disabled", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/api/jobs/test-toggle-id/toggle", http.NoBody)
+		req.SetPathValue("id", "test-toggle-id")
+		w := httptest.NewRecorder()
+
+		server.handleToggleJob(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "refresh-jobs", w.Header().Get("HX-Trigger"))
+
+		server.jobsMu.RLock()
+		assert.False(t, server.jobs["test-toggle-id"].Enabled)
+		server.jobsMu.RUnlock()
+	})
+
+	t.Run("toggle disabled to enabled", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/api/jobs/test-toggle-id/toggle", http.NoBody)
+		req.SetPathValue("id", "test-toggle-id")
+		w := httptest.NewRecorder()
+
+		server.handleToggleJob(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "refresh-jobs", w.Header().Get("HX-Trigger"))
+
+		server.jobsMu.RLock()
+		assert.True(t, server.jobs["test-toggle-id"].Enabled)
+		server.jobsMu.RUnlock()
+	})
+
+	t.Run("job not found", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/api/jobs/nonexistent/toggle", http.NoBody)
+		req.SetPathValue("id", "nonexistent")
+		w := httptest.NewRecorder()
+
+		server.handleToggleJob(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+		assert.Contains(t, w.Body.String(), "Job not found")
+	})
+
+	t.Run("empty job ID", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/api/jobs//toggle", http.NoBody)
+		req.SetPathValue("id", "")
+		w := httptest.NewRecorder()
+
+		server.handleToggleJob(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "Job ID required")
+	})
+
+	t.Run("persistence round-trip", func(t *testing.T) {
+		// ensure job is enabled first
+		server.jobsMu.Lock()
+		j := server.jobs["test-toggle-id"]
+		j.Enabled = true
+		server.jobs["test-toggle-id"] = j
+		server.jobsMu.Unlock()
+
+		// toggle to disabled
+		req := httptest.NewRequest("POST", "/api/jobs/test-toggle-id/toggle", http.NoBody)
+		req.SetPathValue("id", "test-toggle-id")
+		w := httptest.NewRecorder()
+		server.handleToggleJob(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		// verify persisted in DB
+		loaded, err := server.store.LoadJobs()
+		require.NoError(t, err)
+
+		var found bool
+		for _, lj := range loaded {
+			if lj.ID == "test-toggle-id" {
+				assert.False(t, lj.Enabled)
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "job should be found in DB")
+	})
+}

--- a/app/web/handlers_test.go
+++ b/app/web/handlers_test.go
@@ -1445,6 +1445,9 @@ func TestServer_handleToggleJob(t *testing.T) {
 	server.jobs[testJob.ID] = testJob
 	server.jobsMu.Unlock()
 
+	disableToggle := make(chan string, 10)
+	server.disableToggle = disableToggle
+
 	t.Run("toggle enabled to disabled", func(t *testing.T) {
 		req := httptest.NewRequest("POST", "/api/jobs/test-toggle-id/toggle", http.NoBody)
 		req.SetPathValue("id", "test-toggle-id")
@@ -1458,6 +1461,14 @@ func TestServer_handleToggleJob(t *testing.T) {
 		server.jobsMu.RLock()
 		assert.False(t, server.jobs["test-toggle-id"].Enabled)
 		server.jobsMu.RUnlock()
+
+		// verify channel received job ID
+		select {
+		case id := <-disableToggle:
+			assert.Equal(t, "test-toggle-id", id)
+		case <-time.After(time.Second):
+			t.Fatal("expected job ID on disableToggle channel")
+		}
 	})
 
 	t.Run("toggle disabled to enabled", func(t *testing.T) {
@@ -1473,6 +1484,14 @@ func TestServer_handleToggleJob(t *testing.T) {
 		server.jobsMu.RLock()
 		assert.True(t, server.jobs["test-toggle-id"].Enabled)
 		server.jobsMu.RUnlock()
+
+		// verify channel received job ID
+		select {
+		case id := <-disableToggle:
+			assert.Equal(t, "test-toggle-id", id)
+		case <-time.After(time.Second):
+			t.Fatal("expected job ID on disableToggle channel")
+		}
 	})
 
 	t.Run("job not found", func(t *testing.T) {
@@ -1487,7 +1506,7 @@ func TestServer_handleToggleJob(t *testing.T) {
 	})
 
 	t.Run("empty job ID", func(t *testing.T) {
-		req := httptest.NewRequest("POST", "/api/jobs//toggle", http.NoBody)
+		req := httptest.NewRequest("POST", "/api/jobs/toggle", http.NoBody)
 		req.SetPathValue("id", "")
 		w := httptest.NewRecorder()
 

--- a/app/web/static/style.css
+++ b/app/web/static/style.css
@@ -514,6 +514,11 @@ code {
     contain: layout;
 }
 
+.job-card.job-disabled,
+.job-row.job-disabled {
+    opacity: 0.5;
+}
+
 .job-card:hover {
     box-shadow: var(--shadow-hover);
     transform: translateY(-2px);
@@ -1852,6 +1857,35 @@ code {
     color: var(--color-text-muted);
     cursor: not-allowed;
     opacity: 0.5;
+}
+
+.btn-toggle {
+    padding: 3px 8px;
+    font-size: 11px;
+    background: transparent;
+    color: var(--color-text-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+}
+
+.btn-toggle:hover {
+    background: var(--color-surface-hover);
+    color: var(--color-primary);
+    border-color: var(--color-primary);
+}
+
+.btn-toggle.btn-disabled-state {
+    color: var(--color-text-muted);
+    opacity: 0.5;
+}
+
+.btn-toggle.btn-disabled-state:hover {
+    color: var(--color-primary);
+    opacity: 1;
 }
 
 .btn-compact .icon {

--- a/app/web/templates/partials/jobs.html
+++ b/app/web/templates/partials/jobs.html
@@ -1,6 +1,6 @@
 {{define "jobs-cards"}}
 {{range .Jobs}}
-<div class="job-card"
+<div class="job-card{{if not .Enabled}} job-disabled{{end}}"
      data-job-id="{{.ID}}"
      data-job-status="{{.LastStatus}}"
      data-next-run="{{.NextRun.Unix}}">
@@ -53,6 +53,15 @@
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
                     <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
                     <polyline points="12 6 12 12 16 14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                </svg>
+            </button>
+            <button class="btn-toggle {{if not .Enabled}}btn-disabled-state{{end}}"
+                    hx-post="{{url (printf "/api/jobs/%s/toggle" .ID)}}"
+                    hx-swap="none"
+                    title="{{if .Enabled}}Disable{{else}}Enable{{end}} job">
+                <svg class="icon" width="12" height="12" viewBox="0 0 24 24" fill="none">
+                    <path d="M12 2v10" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M18.36 6.64A9 9 0 1 1 5.64 6.64" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
                 </svg>
             </button>
             {{if not $.ManualDisabled}}
@@ -121,7 +130,7 @@
     </thead>
     <tbody>
         {{range .Jobs}}
-        <tr class="job-row"
+        <tr class="job-row{{if not .Enabled}} job-disabled{{end}}"
             data-job-id="{{.ID}}"
             data-job-status="{{.LastStatus}}"
             data-next-run="{{.NextRun.Unix}}">
@@ -194,6 +203,15 @@
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
                         <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
                         <polyline points="12 6 12 12 16 14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    </svg>
+                </button>
+                <button class="btn-toggle {{if not .Enabled}}btn-disabled-state{{end}}"
+                        hx-post="{{url (printf "/api/jobs/%s/toggle" .ID)}}"
+                        hx-swap="none"
+                        title="{{if .Enabled}}Disable{{else}}Enable{{end}} job">
+                    <svg class="icon" width="12" height="12" viewBox="0 0 24 24" fill="none">
+                        <path d="M12 2v10" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                        <path d="M18.36 6.64A9 9 0 1 1 5.64 6.64" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
                     </svg>
                 </button>
                 {{if not $.ManualDisabled}}

--- a/app/web/templates/partials/jobs.html
+++ b/app/web/templates/partials/jobs.html
@@ -102,8 +102,8 @@
     <div class="job-timing">
         <div class="timing-item">
             <span class="timing-label">Next run:</span>
-            <span class="timing-value" title="{{.NextRun.Format "2006-01-02 15:04:05"}}">
-                {{timeUntil .NextRun}}{{if not .NextRun.IsZero}} ({{.NextRun.Format "Jan 2, 15:04"}}){{end}}
+            <span class="timing-value" title="{{if .Enabled}}{{.NextRun.Format "2006-01-02 15:04:05"}}{{else}}disabled{{end}}">
+                {{if not .Enabled}}-{{else}}{{timeUntil .NextRun}}{{if not .NextRun.IsZero}} ({{.NextRun.Format "Jan 2, 15:04"}}){{end}}{{end}}
             </span>
         </div>
         <div class="timing-item">
@@ -179,8 +179,8 @@
             </td>
 
             <td class="td-next numeric">
-                <span class="time-value" title="{{.NextRun.Format "2006-01-02 15:04:05"}}">
-                    {{timeUntil .NextRun}}{{if not .NextRun.IsZero}} ({{.NextRun.Format "Jan 2, 15:04"}}){{end}}
+                <span class="time-value" title="{{if .Enabled}}{{.NextRun.Format "2006-01-02 15:04:05"}}{{else}}disabled{{end}}">
+                    {{if not .Enabled}}-{{else}}{{timeUntil .NextRun}}{{if not .NextRun.IsZero}} ({{.NextRun.Format "Jan 2, 15:04"}}){{end}}{{end}}
                 </span>
             </td>
 
@@ -387,10 +387,9 @@
             <div class="modal-section">
                 <div class="modal-label">Next Run</div>
                 <div class="modal-value">
-                    {{if .NextRun.IsZero}}
-                    Never
-                    {{else}}
-                    {{.NextRun.Format "2006-01-02 15:04:05"}} ({{timeUntil .NextRun}})
+                    {{if not .Enabled}}Disabled
+                    {{else if .NextRun.IsZero}}Never
+                    {{else}}{{.NextRun.Format "2006-01-02 15:04:05"}} ({{timeUntil .NextRun}})
                     {{end}}
                 </div>
             </div>

--- a/app/web/web.go
+++ b/app/web/web.go
@@ -57,7 +57,6 @@ type Server struct {
 	passwordHash       string                          // bcrypt hash for basic auth
 	loginTTL           time.Duration                   // session TTL
 	manualTrigger      chan<- service.ManualJobRequest // channel to send manual trigger requests to scheduler
-	disableToggle      chan<- string                   // channel to send disable toggle events to scheduler
 	csrfProtection     *http.CrossOriginProtection     // csrf protection for POST endpoints
 	sessions           map[string]session              // active user sessions
 	sessionsMu         sync.Mutex                      // protects sessions map
@@ -156,7 +155,6 @@ type Config struct {
 	Hostname           string // hostname to display in UI
 	Version            string
 	ManualTrigger      chan<- service.ManualJobRequest // channel for sending manual trigger requests
-	DisableToggle      chan<- string                   // channel for sending disable toggle events
 	JobsProvider       JobsProvider                    // interface for loading job specifications
 	PasswordHash       string                          // bcrypt hash for basic auth (empty to disable)
 	LoginTTL           time.Duration                   // session TTL, defaults to 24h if not set
@@ -257,7 +255,6 @@ func New(cfg Config) (*Server, error) {
 		passwordHash:       cfg.PasswordHash,
 		loginTTL:           loginTTL,
 		manualTrigger:      cfg.ManualTrigger,
-		disableToggle:      cfg.DisableToggle,
 		csrfProtection:     csrfProtection,
 		disableManual:      cfg.DisableManual,
 		disableCommandEdit: cfg.DisableCommandEdit,
@@ -284,17 +281,6 @@ func New(cfg Config) (*Server, error) {
 func (s *Server) Run(ctx context.Context, address string) error {
 	// load existing job history from database
 	s.loadJobsFromDB()
-
-	// send initially disabled jobs to scheduler
-	if s.disableToggle != nil {
-		s.jobsMu.RLock()
-		for id, job := range s.jobs {
-			if !job.Enabled {
-				s.disableToggle <- id
-			}
-		}
-		s.jobsMu.RUnlock()
-	}
 
 	// start background job sync
 	go s.syncJobs(ctx)
@@ -646,6 +632,14 @@ func (s *Server) cookiePath() string {
 		return "/"
 	}
 	return s.baseURL + "/"
+}
+
+// IsJobDisabled returns true if the job with the given ID is disabled
+func (s *Server) IsJobDisabled(jobID string) bool {
+	s.jobsMu.RLock()
+	defer s.jobsMu.RUnlock()
+	job, exists := s.jobs[jobID]
+	return exists && !job.Enabled
 }
 
 // helper functions

--- a/app/web/web.go
+++ b/app/web/web.go
@@ -378,6 +378,7 @@ func (s *Server) routes() http.Handler {
 		api.HandleFunc("POST /sort-toggle", s.handleSortToggle)
 		api.HandleFunc("POST /filter-toggle", s.handleFilterToggle)
 		api.HandleFunc("POST /jobs/{id}/run", s.handleRunJob)
+		api.HandleFunc("POST /jobs/{id}/toggle", s.handleToggleJob)
 		api.HandleFunc("GET /jobs/{id}/modal", s.handleJobModal)
 		api.HandleFunc("GET /jobs/{id}/history", s.handleJobHistory)
 		api.HandleFunc("GET /settings/modal", s.handleSettingsModal)

--- a/app/web/web.go
+++ b/app/web/web.go
@@ -57,6 +57,7 @@ type Server struct {
 	passwordHash       string                          // bcrypt hash for basic auth
 	loginTTL           time.Duration                   // session TTL
 	manualTrigger      chan<- service.ManualJobRequest // channel to send manual trigger requests to scheduler
+	disableToggle      chan<- string                   // channel to send disable toggle events to scheduler
 	csrfProtection     *http.CrossOriginProtection     // csrf protection for POST endpoints
 	sessions           map[string]session              // active user sessions
 	sessionsMu         sync.Mutex                      // protects sessions map
@@ -155,6 +156,7 @@ type Config struct {
 	Hostname           string // hostname to display in UI
 	Version            string
 	ManualTrigger      chan<- service.ManualJobRequest // channel for sending manual trigger requests
+	DisableToggle      chan<- string                   // channel for sending disable toggle events
 	JobsProvider       JobsProvider                    // interface for loading job specifications
 	PasswordHash       string                          // bcrypt hash for basic auth (empty to disable)
 	LoginTTL           time.Duration                   // session TTL, defaults to 24h if not set
@@ -255,6 +257,7 @@ func New(cfg Config) (*Server, error) {
 		passwordHash:       cfg.PasswordHash,
 		loginTTL:           loginTTL,
 		manualTrigger:      cfg.ManualTrigger,
+		disableToggle:      cfg.DisableToggle,
 		csrfProtection:     csrfProtection,
 		disableManual:      cfg.DisableManual,
 		disableCommandEdit: cfg.DisableCommandEdit,
@@ -281,6 +284,17 @@ func New(cfg Config) (*Server, error) {
 func (s *Server) Run(ctx context.Context, address string) error {
 	// load existing job history from database
 	s.loadJobsFromDB()
+
+	// send initially disabled jobs to scheduler
+	if s.disableToggle != nil {
+		s.jobsMu.RLock()
+		for id, job := range s.jobs {
+			if !job.Enabled {
+				s.disableToggle <- id
+			}
+		}
+		s.jobsMu.RUnlock()
+	}
 
 	// start background job sync
 	go s.syncJobs(ctx)

--- a/e2e/toggle_test.go
+++ b/e2e/toggle_test.go
@@ -1,0 +1,198 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// enableAllJobs re-enables any disabled jobs (cards view)
+func enableAllJobs(t *testing.T, page playwright.Page) {
+	t.Helper()
+	for {
+		disabledCount, err := page.Locator(".job-card.job-disabled").Count()
+		require.NoError(t, err)
+		if disabledCount == 0 {
+			return
+		}
+		require.NoError(t, page.Locator(".job-card.job-disabled .btn-toggle").First().Click())
+		page.WaitForTimeout(1500)
+	}
+}
+
+// --- toggle button tests (cards view) ---
+
+func TestToggle_ButtonExistsOnCards(t *testing.T) {
+	page := newPage(t)
+	navigateToDashboard(t, page)
+	waitForJobsLoaded(t, page)
+
+	count, err := page.Locator(".job-card .btn-toggle").Count()
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, count, 1, "should have toggle buttons on job cards")
+}
+
+func TestToggle_DisablesJob(t *testing.T) {
+	page := newPage(t)
+	navigateToDashboard(t, page)
+	waitForJobsLoaded(t, page)
+
+	// ensure all jobs are enabled first
+	enableAllJobs(t, page)
+
+	// verify first card is NOT disabled
+	firstCard := page.Locator(".job-card").First()
+	hasDisabled, err := firstCard.Evaluate("el => el.classList.contains('job-disabled')", nil)
+	require.NoError(t, err)
+	require.False(t, hasDisabled.(bool), "first card should not be disabled")
+
+	// click toggle button on first job
+	require.NoError(t, page.Locator(".job-card .btn-toggle").First().Click())
+
+	// wait for HTMX refresh
+	require.NoError(t, page.Locator(".job-card.job-disabled").First().WaitFor())
+
+	count, err := page.Locator(".job-card.job-disabled").Count()
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, count, 1, "should have at least one disabled job card")
+
+	// cleanup
+	enableAllJobs(t, page)
+}
+
+func TestToggle_ReEnablesJob(t *testing.T) {
+	page := newPage(t)
+	navigateToDashboard(t, page)
+	waitForJobsLoaded(t, page)
+
+	// ensure clean state, then disable one
+	enableAllJobs(t, page)
+	require.NoError(t, page.Locator(".job-card .btn-toggle").First().Click())
+	require.NoError(t, page.Locator(".job-card.job-disabled").First().WaitFor())
+
+	// re-enable
+	require.NoError(t, page.Locator(".job-card.job-disabled .btn-toggle").First().Click())
+	page.WaitForTimeout(1500)
+
+	afterCount, err := page.Locator(".job-card.job-disabled").Count()
+	require.NoError(t, err)
+	assert.Equal(t, 0, afterCount, "no cards should be disabled after re-enabling")
+}
+
+func TestToggle_DisabledJobHasDisabledRunButton(t *testing.T) {
+	page := newPage(t)
+	navigateToDashboard(t, page)
+	waitForJobsLoaded(t, page)
+
+	// ensure clean state, then disable one
+	enableAllJobs(t, page)
+	require.NoError(t, page.Locator(".job-card .btn-toggle").First().Click())
+	require.NoError(t, page.Locator(".job-card.job-disabled").First().WaitFor())
+
+	// verify the Run button inside a disabled card is disabled
+	runBtnDisabled, err := page.Locator(".job-card.job-disabled .btn-compact[disabled]").Count()
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, runBtnDisabled, 1, "Run button should be disabled when job is disabled")
+
+	// cleanup
+	enableAllJobs(t, page)
+}
+
+func TestToggle_PersistsAcrossReload(t *testing.T) {
+	page := newPage(t)
+	navigateToDashboard(t, page)
+	waitForJobsLoaded(t, page)
+
+	// ensure clean state, then disable one
+	enableAllJobs(t, page)
+	require.NoError(t, page.Locator(".job-card .btn-toggle").First().Click())
+	require.NoError(t, page.Locator(".job-card.job-disabled").First().WaitFor())
+
+	// reload page
+	_, err := page.Reload()
+	require.NoError(t, err)
+	waitVisible(t, page.Locator(".header"))
+	waitForJobsLoaded(t, page)
+
+	// verify the disabled state persisted
+	count, err := page.Locator(".job-card.job-disabled").Count()
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, count, 1, "disabled state should persist after reload")
+
+	// cleanup
+	enableAllJobs(t, page)
+}
+
+// --- toggle button tests (list view) ---
+
+func TestToggle_ButtonExistsInListView(t *testing.T) {
+	page := newPage(t)
+	navigateToDashboard(t, page)
+	waitForJobsLoaded(t, page)
+
+	// switch to list view
+	require.NoError(t, page.Locator(".view-toggle").Click())
+	waitVisible(t, page.Locator(".jobs-table"))
+
+	count, err := page.Locator(".job-row .btn-toggle").Count()
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, count, 1, "should have toggle buttons in list view")
+}
+
+func TestToggle_WorksInListView(t *testing.T) {
+	page := newPage(t)
+	navigateToDashboard(t, page)
+	waitForJobsLoaded(t, page)
+
+	// ensure clean state first (in cards view)
+	enableAllJobs(t, page)
+
+	// switch to list view
+	require.NoError(t, page.Locator(".view-toggle").Click())
+	waitVisible(t, page.Locator(".jobs-table"))
+
+	// click toggle on first row
+	require.NoError(t, page.Locator(".job-row .btn-toggle").First().Click())
+
+	// wait for HTMX refresh
+	require.NoError(t, page.Locator(".job-row.job-disabled").First().WaitFor())
+
+	count, err := page.Locator(".job-row.job-disabled").Count()
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, count, 1, "should have at least one disabled job row")
+
+	// cleanup: switch back to cards and re-enable
+	require.NoError(t, page.Locator(".view-toggle").Click())
+	waitForJobsLoaded(t, page)
+	enableAllJobs(t, page)
+}
+
+func TestToggle_ButtonTitleChanges(t *testing.T) {
+	page := newPage(t)
+	navigateToDashboard(t, page)
+	waitForJobsLoaded(t, page)
+
+	// ensure all enabled
+	enableAllJobs(t, page)
+
+	// should say "Disable job" when enabled
+	title, err := page.Locator(".job-card .btn-toggle").First().GetAttribute("title")
+	require.NoError(t, err)
+	assert.Equal(t, "Disable job", title)
+
+	// toggle to disable
+	require.NoError(t, page.Locator(".job-card .btn-toggle").First().Click())
+	require.NoError(t, page.Locator(".job-card.job-disabled").First().WaitFor())
+
+	// should say "Enable job" when disabled
+	title, err = page.Locator(".job-card.job-disabled .btn-toggle").First().GetAttribute("title")
+	require.NoError(t, err)
+	assert.Equal(t, "Enable job", title)
+
+	// cleanup
+	enableAllJobs(t, page)
+}

--- a/e2e/toggle_test.go
+++ b/e2e/toggle_test.go
@@ -20,7 +20,9 @@ func enableAllJobs(t *testing.T, page playwright.Page) {
 			return
 		}
 		require.NoError(t, page.Locator(".job-card.job-disabled .btn-toggle").First().Click())
-		page.WaitForTimeout(1500)
+		require.NoError(t, page.Locator(".job-card.job-disabled").WaitFor(playwright.LocatorWaitForOptions{
+			State: playwright.WaitForSelectorStateHidden,
+		}))
 	}
 }
 
@@ -76,7 +78,9 @@ func TestToggle_ReEnablesJob(t *testing.T) {
 
 	// re-enable
 	require.NoError(t, page.Locator(".job-card.job-disabled .btn-toggle").First().Click())
-	page.WaitForTimeout(1500)
+	require.NoError(t, page.Locator(".job-card.job-disabled").WaitFor(playwright.LocatorWaitForOptions{
+		State: playwright.WaitForSelectorStateHidden,
+	}))
 
 	afterCount, err := page.Locator(".job-card.job-disabled").Count()
 	require.NoError(t, err)
@@ -170,7 +174,9 @@ func TestToggle_ReEnabledJobShowsNextRun(t *testing.T) {
 	require.NoError(t, page.Locator(".job-card .btn-toggle").First().Click())
 	require.NoError(t, page.Locator(".job-card.job-disabled").First().WaitFor())
 	require.NoError(t, page.Locator(".job-card.job-disabled .btn-toggle").First().Click())
-	page.WaitForTimeout(1500)
+	require.NoError(t, page.Locator(".job-card.job-disabled").WaitFor(playwright.LocatorWaitForOptions{
+		State: playwright.WaitForSelectorStateHidden,
+	}))
 
 	// verify next run is restored (not "-")
 	nextRunText, err := page.Locator(".job-card .timing-value").First().InnerText()

--- a/e2e/toggle_test.go
+++ b/e2e/toggle_test.go
@@ -127,6 +127,88 @@ func TestToggle_PersistsAcrossReload(t *testing.T) {
 	enableAllJobs(t, page)
 }
 
+// --- next run hidden for disabled jobs ---
+
+func TestToggle_DisabledJobHidesNextRun(t *testing.T) {
+	page := newPage(t)
+	navigateToDashboard(t, page)
+	waitForJobsLoaded(t, page)
+
+	enableAllJobs(t, page)
+
+	// verify enabled job shows a real next run value (not "-")
+	nextRunText, err := page.Locator(".job-card .timing-value").First().InnerText()
+	require.NoError(t, err)
+	assert.NotEqual(t, "-", nextRunText, "enabled job should show next run time")
+
+	// disable first job
+	require.NoError(t, page.Locator(".job-card .btn-toggle").First().Click())
+	require.NoError(t, page.Locator(".job-card.job-disabled").First().WaitFor())
+
+	// verify disabled job shows "-" for next run
+	disabledNextRun, err := page.Locator(".job-card.job-disabled .timing-value").First().InnerText()
+	require.NoError(t, err)
+	assert.Equal(t, "-", disabledNextRun, "disabled job should show '-' for next run")
+
+	// verify title attribute says "disabled"
+	title, err := page.Locator(".job-card.job-disabled .timing-value").First().GetAttribute("title")
+	require.NoError(t, err)
+	assert.Equal(t, "disabled", title)
+
+	// cleanup
+	enableAllJobs(t, page)
+}
+
+func TestToggle_ReEnabledJobShowsNextRun(t *testing.T) {
+	page := newPage(t)
+	navigateToDashboard(t, page)
+	waitForJobsLoaded(t, page)
+
+	enableAllJobs(t, page)
+
+	// disable then re-enable
+	require.NoError(t, page.Locator(".job-card .btn-toggle").First().Click())
+	require.NoError(t, page.Locator(".job-card.job-disabled").First().WaitFor())
+	require.NoError(t, page.Locator(".job-card.job-disabled .btn-toggle").First().Click())
+	page.WaitForTimeout(1500)
+
+	// verify next run is restored (not "-")
+	nextRunText, err := page.Locator(".job-card .timing-value").First().InnerText()
+	require.NoError(t, err)
+	assert.NotEqual(t, "-", nextRunText, "re-enabled job should show next run time again")
+}
+
+func TestToggle_DisabledJobHidesNextRunInListView(t *testing.T) {
+	page := newPage(t)
+	navigateToDashboard(t, page)
+	waitForJobsLoaded(t, page)
+
+	enableAllJobs(t, page)
+
+	// switch to list view
+	require.NoError(t, page.Locator(".view-toggle").Click())
+	waitVisible(t, page.Locator(".jobs-table"))
+
+	// verify enabled job shows next run
+	nextRunText, err := page.Locator(".job-row .td-next .time-value").First().InnerText()
+	require.NoError(t, err)
+	assert.NotEqual(t, "-", nextRunText, "enabled job should show next run in list view")
+
+	// disable first job
+	require.NoError(t, page.Locator(".job-row .btn-toggle").First().Click())
+	require.NoError(t, page.Locator(".job-row.job-disabled").First().WaitFor())
+
+	// verify disabled job shows "-"
+	disabledNextRun, err := page.Locator(".job-row.job-disabled .td-next .time-value").First().InnerText()
+	require.NoError(t, err)
+	assert.Equal(t, "-", disabledNextRun, "disabled job should show '-' for next run in list view")
+
+	// cleanup: switch back to cards and re-enable
+	require.NoError(t, page.Locator(".view-toggle").Click())
+	waitForJobsLoaded(t, page)
+	enableAllJobs(t, page)
+}
+
 // --- toggle button tests (list view) ---
 
 func TestToggle_ButtonExistsInListView(t *testing.T) {


### PR DESCRIPTION
## Problem
Currently there is no way to temporarily disable a scheduled job from the web UI. The only options are editing the crontab config or manually updating the SQLite database.

## Summary
- Add toggle button to enable/disable individual jobs from the web dashboard without editing config files
- Disabled jobs are skipped by the scheduler via a callback (`IsJobDisabled`) from the web server
- Next run time is hidden for disabled jobs in both card and list views
- Toggle state persists in SQLite and survives restarts

## Changes
- `POST /api/jobs/{id}/toggle` endpoint with HTMX refresh
- `IsJobDisabled` callback wired from web server to scheduler
- Scheduler calls the callback before executing each job (nil-safe)
- `IsJobDisabled` method on web server reads job state under RLock
- UI: `job-disabled` CSS class, `btn-toggle` button, hidden next run for disabled jobs
- Unit tests for scheduler disable logic (callback true/false/nil) and handler toggle
- E2E tests for toggle UI, persistence, and hidden next run time