### PR TITLE
Add clickable status breakdown to dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,6 +281,16 @@ require.Eventually(t, func() bool {
 }, time.Second, 10*time.Millisecond)
 ```
 
+### E2E Test Requirement
+**CRITICAL: Every UI change must ship with corresponding e2e tests.** Any change to templates (`app/web/templates/`), static assets (`app/web/static/*.css`, `*.js`), or web handlers that affects rendered output requires an e2e test asserting the new behavior in the browser — unit tests on handlers alone are not sufficient.
+
+- Tests live in `e2e/` as Go + Playwright (`//go:build e2e` tag), organized by feature (`e2e_test.go`, `controls_test.go`, `toggle_test.go`, etc.), not one-file-per-source
+- Run with `make e2e` (headless) or `make e2e-ui` (visible browser for debugging)
+- `TestMain` builds the binary once and starts a **single shared server + DB** for the whole run; tests share state and run in file/definition order
+- **Shared-state pattern**: because other tests mutate job state, assert invariants rather than fixed numbers to avoid order-dependent flakiness. Example: verify `total == running + success + failed + idle` instead of hardcoding each count
+- The e2e crontab (`createTestCrontab` in `e2e_test.go`) includes a `*/5` job, so a job may flip to `success` if a run crosses a 5-minute boundary — assert invariants, never an all-idle baseline
+- **Bound every test run by scope and time**: the full e2e suite is slow (~50s per run). Target specific tests with `-run 'TestName'` and always pass `-timeout`; never loop the full suite repeatedly to chase a flake. To confirm a flake fix, run the single affected test, not the whole suite
+
 ## Testing and Development Workflow
 
 ### Restarting Services

--- a/README.md
+++ b/README.md
@@ -305,9 +305,9 @@ Cronn includes a modern web dashboard for monitoring and managing cron jobs. The
 - **Multiple view modes**: Card view and compact list view with toggle button
 - **Sorting options**: Sort jobs by original order, last run time, or next run time
 - **Job enable/disable toggle**: Disable individual jobs from the dashboard without editing config files
-- **Status filtering**: Filter jobs by status (all, running, success, failed)
+- **Status filtering**: Filter jobs by status (all, running, success, failed, idle)
 - **Light, dark, and auto themes** with automatic system preference detection
-- **Job statistics bar** showing total jobs, currently running jobs, and next execution time
+- **Job statistics bar** showing total jobs with a success/failed/idle breakdown, currently running jobs, and next execution time. The total and each breakdown count are clickable to filter jobs by that status, kept in sync with the filter button
 - **Detailed job information** including schedules, commands, and execution history
 - **Status indicators** with color-coded job states (idle, running, success, failed)
 - **Cookie-based preferences** for persistent theme, view mode, sort order, and filter settings

--- a/app/web/enums/enums.go
+++ b/app/web/enums/enums.go
@@ -113,4 +113,5 @@ const (
 	filterModeRunning
 	filterModeSuccess
 	filterModeFailed
+	filterModeIdle
 )

--- a/app/web/enums/event_type_enum.go
+++ b/app/web/enums/event_type_enum.go
@@ -4,6 +4,7 @@ package enums
 import (
 	"database/sql/driver"
 	"fmt"
+	"strings"
 )
 
 // EventType is the exported type for the enum
@@ -73,13 +74,12 @@ var _eventTypeParseMap = map[string]EventType{
 	"failed":    EventTypeFailed,
 }
 
-// ParseEventType converts string to eventType enum value
+// ParseEventType converts string to eventType enum value.
+// Parsing is always case-insensitive.
 func ParseEventType(v string) (EventType, error) {
-
-	if val, ok := _eventTypeParseMap[v]; ok {
+	if val, ok := _eventTypeParseMap[strings.ToLower(v)]; ok {
 		return val, nil
 	}
-
 	return EventType{}, fmt.Errorf("invalid eventType: %s", v)
 }
 

--- a/app/web/enums/filter_mode_enum.go
+++ b/app/web/enums/filter_mode_enum.go
@@ -4,6 +4,7 @@ package enums
 import (
 	"database/sql/driver"
 	"fmt"
+	"strings"
 )
 
 // FilterMode is the exported type for the enum
@@ -72,15 +73,15 @@ var _filterModeParseMap = map[string]FilterMode{
 	"running": FilterModeRunning,
 	"success": FilterModeSuccess,
 	"failed":  FilterModeFailed,
+	"idle":    FilterModeIdle,
 }
 
-// ParseFilterMode converts string to filterMode enum value
+// ParseFilterMode converts string to filterMode enum value.
+// Parsing is always case-insensitive.
 func ParseFilterMode(v string) (FilterMode, error) {
-
-	if val, ok := _filterModeParseMap[v]; ok {
+	if val, ok := _filterModeParseMap[strings.ToLower(v)]; ok {
 		return val, nil
 	}
-
 	return FilterMode{}, fmt.Errorf("invalid filterMode: %s", v)
 }
 
@@ -99,6 +100,7 @@ var (
 	FilterModeRunning = FilterMode{name: "running", value: 1}
 	FilterModeSuccess = FilterMode{name: "success", value: 2}
 	FilterModeFailed  = FilterMode{name: "failed", value: 3}
+	FilterModeIdle    = FilterMode{name: "idle", value: 4}
 )
 
 // FilterModeValues contains all possible enum values
@@ -107,6 +109,7 @@ var FilterModeValues = []FilterMode{
 	FilterModeRunning,
 	FilterModeSuccess,
 	FilterModeFailed,
+	FilterModeIdle,
 }
 
 // FilterModeNames contains all possible enum names
@@ -115,6 +118,7 @@ var FilterModeNames = []string{
 	"running",
 	"success",
 	"failed",
+	"idle",
 }
 
 // FilterModeIter returns a function compatible with Go 1.23's range-over-func syntax.
@@ -146,5 +150,7 @@ var _ = func() bool {
 	var _ filterMode = filterModeSuccess
 	// This avoids "defined but not used" linter error for filterModeFailed
 	var _ filterMode = filterModeFailed
+	// This avoids "defined but not used" linter error for filterModeIdle
+	var _ filterMode = filterModeIdle
 	return true
 }()

--- a/app/web/enums/job_status_enum.go
+++ b/app/web/enums/job_status_enum.go
@@ -4,6 +4,7 @@ package enums
 import (
 	"database/sql/driver"
 	"fmt"
+	"strings"
 )
 
 // JobStatus is the exported type for the enum
@@ -74,13 +75,12 @@ var _jobStatusParseMap = map[string]JobStatus{
 	"failed":  JobStatusFailed,
 }
 
-// ParseJobStatus converts string to jobStatus enum value
+// ParseJobStatus converts string to jobStatus enum value.
+// Parsing is always case-insensitive.
 func ParseJobStatus(v string) (JobStatus, error) {
-
-	if val, ok := _jobStatusParseMap[v]; ok {
+	if val, ok := _jobStatusParseMap[strings.ToLower(v)]; ok {
 		return val, nil
 	}
-
 	return JobStatus{}, fmt.Errorf("invalid jobStatus: %s", v)
 }
 

--- a/app/web/enums/sort_mode_enum.go
+++ b/app/web/enums/sort_mode_enum.go
@@ -4,6 +4,7 @@ package enums
 import (
 	"database/sql/driver"
 	"fmt"
+	"strings"
 )
 
 // SortMode is the exported type for the enum
@@ -73,13 +74,12 @@ var _sortModeParseMap = map[string]SortMode{
 	"nextrun": SortModeNextrun,
 }
 
-// ParseSortMode converts string to sortMode enum value
+// ParseSortMode converts string to sortMode enum value.
+// Parsing is always case-insensitive.
 func ParseSortMode(v string) (SortMode, error) {
-
-	if val, ok := _sortModeParseMap[v]; ok {
+	if val, ok := _sortModeParseMap[strings.ToLower(v)]; ok {
 		return val, nil
 	}
-
 	return SortMode{}, fmt.Errorf("invalid sortMode: %s", v)
 }
 

--- a/app/web/enums/theme_enum.go
+++ b/app/web/enums/theme_enum.go
@@ -4,6 +4,7 @@ package enums
 import (
 	"database/sql/driver"
 	"fmt"
+	"strings"
 )
 
 // Theme is the exported type for the enum
@@ -72,13 +73,12 @@ var _themeParseMap = map[string]Theme{
 	"dark":  ThemeDark,
 }
 
-// ParseTheme converts string to theme enum value
+// ParseTheme converts string to theme enum value.
+// Parsing is always case-insensitive.
 func ParseTheme(v string) (Theme, error) {
-
-	if val, ok := _themeParseMap[v]; ok {
+	if val, ok := _themeParseMap[strings.ToLower(v)]; ok {
 		return val, nil
 	}
-
 	return Theme{}, fmt.Errorf("invalid theme: %s", v)
 }
 

--- a/app/web/enums/view_mode_enum.go
+++ b/app/web/enums/view_mode_enum.go
@@ -4,6 +4,7 @@ package enums
 import (
 	"database/sql/driver"
 	"fmt"
+	"strings"
 )
 
 // ViewMode is the exported type for the enum
@@ -72,13 +73,12 @@ var _viewModeParseMap = map[string]ViewMode{
 	"list":  ViewModeList,
 }
 
-// ParseViewMode converts string to viewMode enum value
+// ParseViewMode converts string to viewMode enum value.
+// Parsing is always case-insensitive.
 func ParseViewMode(v string) (ViewMode, error) {
-
-	if val, ok := _viewModeParseMap[v]; ok {
+	if val, ok := _viewModeParseMap[strings.ToLower(v)]; ok {
 		return val, nil
 	}
-
 	return ViewMode{}, fmt.Errorf("invalid viewMode: %s", v)
 }
 

--- a/app/web/handlers.go
+++ b/app/web/handlers.go
@@ -27,6 +27,9 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	data.RunningCount = stats.runningCount
 	data.NextRunTime = stats.nextRunTime
 	data.TotalCount = stats.totalCount
+	data.SuccessCount = stats.successCount
+	data.FailedCount = stats.failedCount
+	data.IdleCount = stats.idleCount
 	data.AuthEnabled = s.passwordHash != ""
 	data.Version = shortVersion(s.version)
 	data.FullVersion = s.version
@@ -39,6 +42,9 @@ func (s *Server) getJobsWithStats(sortMode enums.SortMode, filterMode enums.Filt
 	s.jobsMu.RLock()
 	allJobs := make([]persistence.JobInfo, 0, len(s.jobs))
 	runningCount := 0
+	successCount := 0
+	failedCount := 0
+	idleCount := 0
 	var nearestNextRun *time.Time
 
 	// first collect all jobs and calculate stats
@@ -53,6 +59,16 @@ func (s *Server) getJobsWithStats(sortMode enums.SortMode, filterMode enums.Filt
 		// count running jobs
 		if jobCopy.IsRunning {
 			runningCount++
+		}
+
+		// count jobs by last status; running jobs have LastStatus running, so they fall out of these
+		switch jobCopy.LastStatus {
+		case enums.JobStatusSuccess:
+			successCount++
+		case enums.JobStatusFailed:
+			failedCount++
+		case enums.JobStatusIdle:
+			idleCount++
 		}
 
 		// find nearest next run (skip disabled jobs)
@@ -85,6 +101,9 @@ func (s *Server) getJobsWithStats(sortMode enums.SortMode, filterMode enums.Filt
 		runningCount: runningCount,
 		nextRunTime:  nextRunTime,
 		totalCount:   totalCount,
+		successCount: successCount,
+		failedCount:  failedCount,
+		idleCount:    idleCount,
 	}
 }
 
@@ -98,6 +117,9 @@ func (s *Server) handleJobsPartial(w http.ResponseWriter, r *http.Request) {
 	data.RunningCount = stats.runningCount
 	data.NextRunTime = stats.nextRunTime
 	data.TotalCount = stats.totalCount
+	data.SuccessCount = stats.successCount
+	data.FailedCount = stats.failedCount
+	data.IdleCount = stats.idleCount
 	data.IsOOB = true // enable OOB for stats updates
 
 	// render jobs partial with stats updates
@@ -141,6 +163,18 @@ func (s *Server) renderJobsWithStats(w http.ResponseWriter, data TemplateData) e
 		}
 	}
 
+	// render total tile and breakdown if OOB to refresh status counts and active filter highlight during polling
+	var totalHTML bytes.Buffer
+	var breakdownHTML bytes.Buffer
+	if data.IsOOB {
+		if err := tmpl.ExecuteTemplate(&totalHTML, "stats-total", data); err != nil {
+			return fmt.Errorf("failed to render stats total: %w", err)
+		}
+		if err := tmpl.ExecuteTemplate(&breakdownHTML, "stats-breakdown", data); err != nil {
+			return fmt.Errorf("failed to render stats breakdown: %w", err)
+		}
+	}
+
 	// write response
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
@@ -153,6 +187,16 @@ func (s *Server) renderJobsWithStats(w http.ResponseWriter, data TemplateData) e
 	if buttonHTML.Len() > 0 {
 		if _, err := w.Write(buttonHTML.Bytes()); err != nil {
 			log.Printf("[ERROR] failed to write button HTML: %v", err)
+		}
+	}
+	if totalHTML.Len() > 0 {
+		if _, err := w.Write(totalHTML.Bytes()); err != nil {
+			log.Printf("[ERROR] failed to write total HTML: %v", err)
+		}
+	}
+	if breakdownHTML.Len() > 0 {
+		if _, err := w.Write(breakdownHTML.Bytes()); err != nil {
+			log.Printf("[ERROR] failed to write breakdown HTML: %v", err)
 		}
 	}
 
@@ -188,6 +232,9 @@ func (s *Server) handleViewModeToggle(w http.ResponseWriter, r *http.Request) {
 	data.TotalCount = stats.totalCount
 	data.RunningCount = stats.runningCount
 	data.NextRunTime = stats.nextRunTime
+	data.SuccessCount = stats.successCount
+	data.FailedCount = stats.failedCount
+	data.IdleCount = stats.idleCount
 	data.CurrentYear = time.Now().Year()
 	data.IsOOB = true
 
@@ -265,6 +312,9 @@ func (s *Server) handleSortToggle(w http.ResponseWriter, r *http.Request) {
 	data.RunningCount = stats.runningCount
 	data.NextRunTime = stats.nextRunTime
 	data.TotalCount = stats.totalCount
+	data.SuccessCount = stats.successCount
+	data.FailedCount = stats.failedCount
+	data.IdleCount = stats.idleCount
 
 	// render jobs and send response with OOB updates
 	if err := s.renderSortedJobs(w, data); err != nil {
@@ -332,6 +382,40 @@ func (s *Server) handleFilterToggle(w http.ResponseWriter, r *http.Request) {
 	data.RunningCount = stats.runningCount
 	data.NextRunTime = stats.nextRunTime
 	data.TotalCount = stats.totalCount
+	data.SuccessCount = stats.successCount
+	data.FailedCount = stats.failedCount
+	data.IdleCount = stats.idleCount
+
+	// render jobs and send response with OOB updates
+	if err := s.renderFilteredJobs(w, data); err != nil {
+		log.Printf("[ERROR] failed to render filtered jobs: %v", err)
+		http.Error(w, "Failed to render jobs", http.StatusInternalServerError)
+	}
+}
+
+// handleFilterModeChange sets a specific filter mode (used by the clickable status breakdown)
+func (s *Server) handleFilterModeChange(w http.ResponseWriter, r *http.Request) {
+	filterMode, err := enums.ParseFilterMode(r.FormValue("filter"))
+	if err != nil {
+		log.Printf("[WARN] invalid filter mode %q: %v", r.FormValue("filter"), err)
+		filterMode = enums.FilterModeAll
+	}
+	s.setFilterCookie(w, filterMode)
+
+	// get filtered jobs for the selected mode
+	searchTerm := r.FormValue("search")
+	stats := s.getJobsWithStats(s.getSortMode(r), filterMode, searchTerm)
+
+	// prepare template data
+	data := s.newTemplateData(r)
+	data.Jobs = stats.jobs
+	data.FilterMode = filterMode
+	data.RunningCount = stats.runningCount
+	data.NextRunTime = stats.nextRunTime
+	data.TotalCount = stats.totalCount
+	data.SuccessCount = stats.successCount
+	data.FailedCount = stats.failedCount
+	data.IdleCount = stats.idleCount
 
 	// render jobs and send response with OOB updates
 	if err := s.renderFilteredJobs(w, data); err != nil {
@@ -375,11 +459,24 @@ func (s *Server) renderFilteredJobs(w http.ResponseWriter, data TemplateData) er
 		RunningCount: data.RunningCount,
 		NextRunTime:  data.NextRunTime,
 		TotalCount:   data.TotalCount,
+		SuccessCount: data.SuccessCount,
+		FailedCount:  data.FailedCount,
+		IdleCount:    data.IdleCount,
 		IsOOB:        true,
 	}
 	var statsHTML bytes.Buffer
 	if err := tmpl.ExecuteTemplate(&statsHTML, "stats-updates", statsData); err != nil {
 		return fmt.Errorf("failed to render stats updates template: %w", err)
+	}
+
+	// render total tile and breakdown with OOB to sync active filter highlight and status counts
+	var totalHTML bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&totalHTML, "stats-total", buttonData); err != nil {
+		return fmt.Errorf("failed to render stats total template: %w", err)
+	}
+	var breakdownHTML bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&breakdownHTML, "stats-breakdown", buttonData); err != nil {
+		return fmt.Errorf("failed to render stats breakdown template: %w", err)
 	}
 
 	// write response with all OOB updates
@@ -392,6 +489,12 @@ func (s *Server) renderFilteredJobs(w http.ResponseWriter, data TemplateData) er
 	}
 	if _, err := w.Write(statsHTML.Bytes()); err != nil {
 		log.Printf("[ERROR] failed to write stats HTML: %v", err)
+	}
+	if _, err := w.Write(totalHTML.Bytes()); err != nil {
+		log.Printf("[ERROR] failed to write total HTML: %v", err)
+	}
+	if _, err := w.Write(breakdownHTML.Bytes()); err != nil {
+		log.Printf("[ERROR] failed to write breakdown HTML: %v", err)
 	}
 
 	return nil

--- a/app/web/handlers_test.go
+++ b/app/web/handlers_test.go
@@ -586,6 +586,68 @@ func TestServer_handleSortToggle(t *testing.T) {
 	}
 }
 
+func TestServer_handleFilterModeChange(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	parser := crontab.New("test-crontab", 0, nil)
+	server, err := New(Config{DBPath: dbPath, UpdateInterval: time.Minute, JobsProvider: parser})
+	require.NoError(t, err)
+	defer server.store.Close()
+
+	server.jobs = map[string]persistence.JobInfo{
+		"1": {ID: "1", Command: "cmd1", IsRunning: true, LastStatus: enums.JobStatusRunning},
+		"2": {ID: "2", Command: "cmd2", LastStatus: enums.JobStatusSuccess},
+		"3": {ID: "3", Command: "cmd3", LastStatus: enums.JobStatusFailed},
+		"4": {ID: "4", Command: "cmd4", LastStatus: enums.JobStatusIdle},
+	}
+
+	tmpl := template.New("partials")
+	tmpl = template.Must(tmpl.New("jobs-cards").Parse(`{{range .Jobs}}{{.Command}} {{end}}`))
+	tmpl = template.Must(tmpl.New("jobs-list").Parse(`{{range .Jobs}}{{.Command}} {{end}}`))
+	tmpl = template.Must(tmpl.New("filter-button").Parse(`<button><span id="filter-label">{{.FilterMode.String}}</span></button>`))
+	tmpl = template.Must(tmpl.New("stats-updates").Parse(`{{if .IsOOB}}<span id="running-count">{{.RunningCount}}</span>{{end}}`))
+	tmpl = template.Must(tmpl.New("stats-total").Parse(`<button id="stat-total" class="stat-total{{if eq .FilterMode.String "all"}} active{{end}}">{{.TotalCount}}</button>`))
+	tmpl = template.Must(tmpl.New("stats-breakdown").Parse(`<div id="stats-breakdown"><button class="breakdown-{{.FilterMode.String}} active">x</button></div>`))
+	server.templates = map[string]*template.Template{"partials/jobs.html": tmpl}
+
+	tests := []struct {
+		name       string
+		filter     string
+		wantCookie string
+		wantJobs   string // command expected in the filtered jobs body
+		wantActive string // active breakdown class expected
+	}{
+		{"success", "success", "success", "cmd2", "breakdown-success active"},
+		{"failed", "failed", "failed", "cmd3", "breakdown-failed active"},
+		{"idle", "idle", "idle", "cmd4", "breakdown-idle active"},
+		{"invalid falls back to all", "bogus", "all", "cmd1", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "/api/filter-mode", strings.NewReader("filter="+tc.filter))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			w := httptest.NewRecorder()
+			server.handleFilterModeChange(w, req)
+
+			resp := w.Result()
+			defer resp.Body.Close()
+
+			cookies := resp.Cookies()
+			require.Len(t, cookies, 1)
+			assert.Equal(t, "filter-mode", cookies[0].Name)
+			assert.Equal(t, tc.wantCookie, cookies[0].Value)
+
+			body := w.Body.String()
+			assert.Contains(t, body, tc.wantJobs)
+			if tc.wantActive != "" {
+				assert.Contains(t, body, tc.wantActive)
+			}
+		})
+	}
+}
+
 func TestServer_handleFilterToggle(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")
@@ -610,8 +672,10 @@ func TestServer_handleFilterToggle(t *testing.T) {
 	tmpl := template.New("partials")
 	tmpl = template.Must(tmpl.New("jobs-cards").Parse(`{{range .Jobs}}{{.Command}}{{end}}`))
 	tmpl = template.Must(tmpl.New("jobs-list").Parse(`{{range .Jobs}}{{.Command}}{{end}}`))
-	tmpl = template.Must(tmpl.New("filter-button").Parse(`<button><span id="filter-label">{{if eq .FilterMode.String "all"}}All Jobs{{else if eq .FilterMode.String "running"}}Running{{else if eq .FilterMode.String "success"}}Success{{else}}Failed{{end}}</span></button>`))
-	tmpl = template.Must(tmpl.New("stats-updates").Parse(`{{if .IsOOB}}<span id="running-count" hx-swap-oob="innerHTML">{{.RunningCount}}</span><span id="next-run" hx-swap-oob="innerHTML">{{.NextRunTime}}</span><span id="total-count" hx-swap-oob="innerHTML">{{.TotalCount}}</span>{{end}}`))
+	tmpl = template.Must(tmpl.New("filter-button").Parse(`<button><span id="filter-label">{{if eq .FilterMode.String "all"}}All Jobs{{else if eq .FilterMode.String "running"}}Running{{else if eq .FilterMode.String "success"}}Success{{else if eq .FilterMode.String "failed"}}Failed{{else}}Idle{{end}}</span></button>`))
+	tmpl = template.Must(tmpl.New("stats-updates").Parse(`{{if .IsOOB}}<span id="running-count" hx-swap-oob="innerHTML">{{.RunningCount}}</span><span id="next-run" hx-swap-oob="innerHTML">{{.NextRunTime}}</span>{{end}}`))
+	tmpl = template.Must(tmpl.New("stats-total").Parse(`<button id="stat-total" class="stat-total{{if eq .FilterMode.String "all"}} active{{end}}">{{.TotalCount}}</button>`))
+	tmpl = template.Must(tmpl.New("stats-breakdown").Parse(`<div id="stats-breakdown"><button class="breakdown-ok{{if eq .FilterMode.String "success"}} active{{end}}">{{.SuccessCount}}</button><button class="breakdown-failed{{if eq .FilterMode.String "failed"}} active{{end}}">{{.FailedCount}}</button><button class="breakdown-idle{{if eq .FilterMode.String "idle"}} active{{end}}">{{.IdleCount}}</button></div>`))
 	server.templates = map[string]*template.Template{
 		"partials/jobs.html": tmpl,
 	}
@@ -624,7 +688,8 @@ func TestServer_handleFilterToggle(t *testing.T) {
 		{"all", "running", "Running"},
 		{"running", "success", "Success"},
 		{"success", "failed", "Failed"},
-		{"failed", "all", "All Jobs"},
+		{"failed", "idle", "Idle"},
+		{"idle", "all", "All Jobs"},
 	}
 
 	for _, tc := range tests {
@@ -711,6 +776,9 @@ func TestServer_getJobsWithStats_WithFilter(t *testing.T) {
 		assert.Len(t, stats.jobs, 5)
 		assert.Equal(t, 2, stats.runningCount)
 		assert.Equal(t, 5, stats.totalCount)
+		assert.Equal(t, 2, stats.successCount)
+		assert.Equal(t, 1, stats.failedCount)
+		assert.Equal(t, 0, stats.idleCount)
 		assert.NotEqual(t, "-", stats.nextRunTime)
 	})
 
@@ -751,6 +819,46 @@ func TestServer_getJobsWithStats_WithFilter(t *testing.T) {
 				assert.True(t, stats.jobs[i-1].NextRun.Before(stats.jobs[i].NextRun) ||
 					stats.jobs[i-1].NextRun.Equal(stats.jobs[i].NextRun))
 			}
+		}
+	})
+}
+
+func TestServer_getJobsWithStats_StatusBreakdown(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	parser := crontab.New("test-crontab", 0, nil)
+	server, err := New(Config{DBPath: dbPath, UpdateInterval: time.Minute, JobsProvider: parser})
+	require.NoError(t, err)
+	defer server.store.Close()
+
+	now := time.Now()
+	server.jobs = map[string]persistence.JobInfo{
+		"1": {ID: "1", Command: "running1", IsRunning: true, LastStatus: enums.JobStatusRunning, NextRun: now.Add(time.Hour), Enabled: true},
+		"2": {ID: "2", Command: "success1", LastStatus: enums.JobStatusSuccess, NextRun: now.Add(2 * time.Hour), Enabled: true},
+		"3": {ID: "3", Command: "success2", LastStatus: enums.JobStatusSuccess, NextRun: now.Add(3 * time.Hour), Enabled: true},
+		"4": {ID: "4", Command: "failed1", LastStatus: enums.JobStatusFailed, NextRun: now.Add(4 * time.Hour), Enabled: true},
+		"5": {ID: "5", Command: "idle1", LastStatus: enums.JobStatusIdle, NextRun: now.Add(5 * time.Hour), Enabled: true},
+		"6": {ID: "6", Command: "idle2", LastStatus: enums.JobStatusIdle, Enabled: false},
+	}
+
+	// breakdown counts are computed over all jobs before filtering, so they stay constant across filter modes
+	for _, fm := range []enums.FilterMode{enums.FilterModeAll, enums.FilterModeRunning, enums.FilterModeSuccess, enums.FilterModeFailed, enums.FilterModeIdle} {
+		t.Run(fm.String(), func(t *testing.T) {
+			stats := server.getJobsWithStats(enums.SortModeDefault, fm, "")
+			assert.Equal(t, 6, stats.totalCount)
+			assert.Equal(t, 1, stats.runningCount)
+			assert.Equal(t, 2, stats.successCount)
+			assert.Equal(t, 1, stats.failedCount)
+			assert.Equal(t, 2, stats.idleCount)
+		})
+	}
+
+	t.Run("filter idle returns only idle jobs", func(t *testing.T) {
+		stats := server.getJobsWithStats(enums.SortModeDefault, enums.FilterModeIdle, "")
+		assert.Len(t, stats.jobs, 2)
+		for _, job := range stats.jobs {
+			assert.Equal(t, enums.JobStatusIdle, job.LastStatus)
 		}
 	})
 }

--- a/app/web/jobs.go
+++ b/app/web/jobs.go
@@ -374,6 +374,10 @@ func (s *Server) filterJobs(jobs []persistence.JobInfo, filterMode enums.FilterM
 			if job.LastStatus == enums.JobStatusFailed {
 				filtered = append(filtered, job)
 			}
+		case enums.FilterModeIdle:
+			if job.LastStatus == enums.JobStatusIdle {
+				filtered = append(filtered, job)
+			}
 		}
 	}
 	return filtered

--- a/app/web/static/style.css
+++ b/app/web/static/style.css
@@ -442,6 +442,10 @@ code {
     background: var(--color-error);
 }
 
+.filter-indicator.idle {
+    background: var(--color-warning);
+}
+
 /* Main content */
 .main-content {
     flex: 1;
@@ -473,7 +477,35 @@ code {
     display: flex;
     flex-direction: column;
     align-items: center;
+    justify-content: center;
     text-align: center;
+}
+
+.stat-total {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--spacing-1);
+    padding: var(--spacing-sm) var(--spacing-md);
+    border: none;
+    border-radius: var(--radius-md);
+    background: none;
+    font-family: inherit;
+    cursor: pointer;
+    transition: background 0.15s ease;
+}
+
+.stat-total:hover {
+    background: var(--color-surface-hover);
+}
+
+.stat-total:focus-visible {
+    outline: 2px solid var(--color-info);
+    outline-offset: 1px;
+}
+
+.stat-total.active {
+    background: color-mix(in srgb, var(--color-info) 14%, transparent);
 }
 
 .stat-value {
@@ -487,6 +519,96 @@ code {
     font-size: var(--text-sm);
     font-weight: var(--font-medium);
     margin-top: var(--spacing-1);
+}
+
+.stat-breakdown {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    width: 100%;
+    margin-top: var(--spacing-md);
+    padding-top: var(--spacing-md);
+    border-top: 1px solid var(--color-border);
+}
+
+.breakdown-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 3px;
+    position: relative;
+    padding: var(--spacing-sm) var(--spacing-sm);
+    border: none;
+    border-radius: var(--radius-sm);
+    background: none;
+    font-family: inherit;
+    cursor: pointer;
+    transition: background 0.15s ease;
+}
+
+.breakdown-item + .breakdown-item::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    height: 60%;
+    border-left: 1px solid var(--color-border);
+}
+
+.breakdown-item:hover {
+    background: var(--color-surface-hover);
+}
+
+.breakdown-item:focus-visible {
+    outline: 2px solid var(--color-info);
+    outline-offset: 1px;
+}
+
+.breakdown-item.active {
+    background: var(--color-surface-hover);
+}
+
+.breakdown-count {
+    font-size: var(--text-lg);
+    font-weight: var(--font-semibold);
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+}
+
+.breakdown-label {
+    font-size: var(--text-xs);
+    font-weight: var(--font-medium);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-secondary);
+}
+
+.breakdown-ok .breakdown-count {
+    color: var(--color-success);
+}
+
+.breakdown-failed .breakdown-count {
+    color: var(--color-error);
+}
+
+.breakdown-idle .breakdown-count {
+    color: var(--color-warning);
+}
+
+.breakdown-item.active .breakdown-label {
+    color: var(--color-text);
+}
+
+.breakdown-ok.active {
+    background: color-mix(in srgb, var(--color-success) 16%, transparent);
+}
+
+.breakdown-failed.active {
+    background: color-mix(in srgb, var(--color-error) 16%, transparent);
+}
+
+.breakdown-idle.active {
+    background: color-mix(in srgb, var(--color-warning) 16%, transparent);
 }
 
 
@@ -539,7 +661,11 @@ code {
 }
 
 .job-card[data-job-status="idle"] {
-    border-left-color: var(--color-text-muted);
+    border-left-color: #d6a93a;
+}
+
+[data-theme="dark"] .job-card[data-job-status="idle"] {
+    border-left-color: #d6b24a;
 }
 
 .job-status {
@@ -560,7 +686,11 @@ code {
 }
 
 .status-indicator.idle {
-    background: var(--color-text-muted);
+    background: #d6a93a;
+}
+
+[data-theme="dark"] .status-indicator.idle {
+    background: #d6b24a;
 }
 
 .status-indicator.running {
@@ -806,23 +936,23 @@ code {
 }
 
 .status-badge.idle {
-    background: #f1f5f9;
-    color: #64748b;
-    border: 1px solid #e2e8f0;
+    background: #fef6da;
+    color: #8a6d1f;
+    border: 1px solid #fdeeb8;
 }
 
 .status-badge.idle .status-dot {
-    background: #94a3b8;
+    background: #d6a93a;
 }
 
 [data-theme="dark"] .status-badge.idle {
-    background: #404040;
-    color: #b0b0b0;
-    border: 1px solid #555555;
+    background: #4a4128;
+    color: #d6bd78;
+    border: 1px solid #5a5038;
 }
 
 [data-theme="dark"] .status-badge.idle .status-dot {
-    background: #888888;
+    background: #d6b24a;
 }
 
 .status-badge.running {

--- a/app/web/static/style.css
+++ b/app/web/static/style.css
@@ -24,7 +24,11 @@
     --color-warning: #d97706;
     --color-info: #2563eb;
     --color-running: #2563eb;
-    
+    --color-idle: #d6a93a;
+    --color-idle-bg: #fef6da;
+    --color-idle-border: #fdeeb8;
+    --color-idle-text: #8a6d1f;
+
     /* Spacing - 4/8/12/16/24/32/48 scale */
     --spacing-1: 4px;
     --spacing-2: 8px;
@@ -89,6 +93,10 @@
     --color-warning: #fbbf24;
     --color-info: #60a5fa;
     --color-running: #60a5fa;
+    --color-idle: #d6b24a;
+    --color-idle-bg: #4a4128;
+    --color-idle-border: #5a5038;
+    --color-idle-text: #d6bd78;
 }
 
 /* Auto theme - follows system */
@@ -108,6 +116,10 @@
         --color-warning: #fbbf24;
         --color-info: #60a5fa;
         --color-running: #60a5fa;
+        --color-idle: #d6b24a;
+        --color-idle-bg: #4a4128;
+        --color-idle-border: #5a5038;
+        --color-idle-text: #d6bd78;
     }
 }
 
@@ -661,11 +673,7 @@ code {
 }
 
 .job-card[data-job-status="idle"] {
-    border-left-color: #d6a93a;
-}
-
-[data-theme="dark"] .job-card[data-job-status="idle"] {
-    border-left-color: #d6b24a;
+    border-left-color: var(--color-idle);
 }
 
 .job-status {
@@ -686,11 +694,7 @@ code {
 }
 
 .status-indicator.idle {
-    background: #d6a93a;
-}
-
-[data-theme="dark"] .status-indicator.idle {
-    background: #d6b24a;
+    background: var(--color-idle);
 }
 
 .status-indicator.running {
@@ -936,23 +940,13 @@ code {
 }
 
 .status-badge.idle {
-    background: #fef6da;
-    color: #8a6d1f;
-    border: 1px solid #fdeeb8;
+    background: var(--color-idle-bg);
+    color: var(--color-idle-text);
+    border: 1px solid var(--color-idle-border);
 }
 
 .status-badge.idle .status-dot {
-    background: #d6a93a;
-}
-
-[data-theme="dark"] .status-badge.idle {
-    background: #4a4128;
-    color: #d6bd78;
-    border: 1px solid #5a5038;
-}
-
-[data-theme="dark"] .status-badge.idle .status-dot {
-    background: #d6b24a;
+    background: var(--color-idle);
 }
 
 .status-badge.running {

--- a/app/web/templates/dashboard.html
+++ b/app/web/templates/dashboard.html
@@ -3,8 +3,8 @@
     <!-- Stats bar -->
     <div class="stats-bar">
         <div class="stat">
-            <span class="stat-value" id="total-count">{{.TotalCount}}</span>
-            <span class="stat-label">Total Jobs</span>
+            {{template "stats-total" .}}
+            {{template "stats-breakdown" .}}
         </div>
         <div class="stat">
             <span class="stat-value" id="running-count">{{.RunningCount}}</span>

--- a/app/web/templates/partials/jobs.html
+++ b/app/web/templates/partials/jobs.html
@@ -249,7 +249,7 @@
         <path d="M22 3H2l8 9.46V19l4 2v-8.54L22 3z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
     <span class="filter-label" id="filter-label">
-        {{if eq .FilterMode.String "all"}}All Jobs{{else if eq .FilterMode.String "running"}}Running{{else if eq .FilterMode.String "success"}}Success{{else}}Failed{{end}}
+        {{if eq .FilterMode.String "all"}}All Jobs{{else if eq .FilterMode.String "running"}}Running{{else if eq .FilterMode.String "success"}}Success{{else if eq .FilterMode.String "failed"}}Failed{{else}}Idle{{end}}
     </span>
     {{if ne .FilterMode.String "all"}}
     <span class="filter-indicator {{.FilterMode.String}}"></span>
@@ -324,8 +324,52 @@
 {{if .IsOOB}}
 <span id="running-count" hx-swap-oob="innerHTML">{{.RunningCount}}</span>
 <span id="next-run" hx-swap-oob="innerHTML">{{.NextRunTime}}</span>
-<span id="total-count" hx-swap-oob="innerHTML">{{.TotalCount}}</span>
 {{end}}
+{{end}}
+
+{{define "stats-total"}}
+<button class="stat-total{{if eq .FilterMode.String "all"}} active{{end}}" id="stat-total"
+        {{if .IsOOB}}hx-swap-oob="outerHTML:#stat-total"{{end}}
+        hx-post="{{url "/api/filter-mode"}}"
+        hx-vals="js:{filter: 'all', search: document.querySelector('[name=search]')?.value || ''}"
+        hx-target="#jobs-container"
+        hx-swap="innerHTML"
+        title="Show all jobs">
+    <span class="stat-value" id="total-count">{{.TotalCount}}</span>
+    <span class="stat-label">Total Jobs</span>
+</button>
+{{end}}
+
+{{define "stats-breakdown"}}
+<div class="stat-breakdown" id="stats-breakdown" {{if .IsOOB}}hx-swap-oob="outerHTML:#stats-breakdown"{{end}}>
+    <button class="breakdown-item breakdown-ok{{if eq .FilterMode.String "success"}} active{{end}}"
+            hx-post="{{url "/api/filter-mode"}}"
+            hx-vals="js:{filter: 'success', search: document.querySelector('[name=search]')?.value || ''}"
+            hx-target="#jobs-container"
+            hx-swap="innerHTML"
+            title="Filter by succeeded jobs">
+        <span class="breakdown-count" id="success-count">{{.SuccessCount}}</span>
+        <span class="breakdown-label">ok</span>
+    </button>
+    <button class="breakdown-item breakdown-failed{{if eq .FilterMode.String "failed"}} active{{end}}"
+            hx-post="{{url "/api/filter-mode"}}"
+            hx-vals="js:{filter: 'failed', search: document.querySelector('[name=search]')?.value || ''}"
+            hx-target="#jobs-container"
+            hx-swap="innerHTML"
+            title="Filter by failed jobs">
+        <span class="breakdown-count" id="failed-count">{{.FailedCount}}</span>
+        <span class="breakdown-label">failed</span>
+    </button>
+    <button class="breakdown-item breakdown-idle{{if eq .FilterMode.String "idle"}} active{{end}}"
+            hx-post="{{url "/api/filter-mode"}}"
+            hx-vals="js:{filter: 'idle', search: document.querySelector('[name=search]')?.value || ''}"
+            hx-target="#jobs-container"
+            hx-swap="innerHTML"
+            title="Filter by never-run jobs">
+        <span class="breakdown-count" id="idle-count">{{.IdleCount}}</span>
+        <span class="breakdown-label">idle</span>
+    </button>
+</div>
 {{end}}
 
 {{define "job-modal"}}

--- a/app/web/web.go
+++ b/app/web/web.go
@@ -116,6 +116,9 @@ type TemplateData struct {
 	RunningCount       int    // for stats display
 	NextRunTime        string // formatted next run time for stats
 	TotalCount         int    // total jobs before filtering
+	SuccessCount       int    // jobs whose last run succeeded
+	FailedCount        int    // jobs whose last run failed
+	IdleCount          int    // jobs that have not run yet
 	IsOOB              bool   // for OOB template rendering
 	AuthEnabled        bool   // whether authentication is enabled
 	Version            string // application version (short form)
@@ -145,6 +148,9 @@ type jobsStats struct {
 	runningCount int
 	nextRunTime  string
 	totalCount   int
+	successCount int
+	failedCount  int
+	idleCount    int
 }
 
 // Config holds server configuration
@@ -377,6 +383,7 @@ func (s *Server) routes() http.Handler {
 		api.HandleFunc("POST /sort-mode", s.handleSortModeChange)
 		api.HandleFunc("POST /sort-toggle", s.handleSortToggle)
 		api.HandleFunc("POST /filter-toggle", s.handleFilterToggle)
+		api.HandleFunc("POST /filter-mode", s.handleFilterModeChange)
 		api.HandleFunc("POST /jobs/{id}/run", s.handleRunJob)
 		api.HandleFunc("POST /jobs/{id}/toggle", s.handleToggleJob)
 		api.HandleFunc("GET /jobs/{id}/modal", s.handleJobModal)
@@ -549,7 +556,7 @@ func (s *Server) setSortCookie(w http.ResponseWriter, mode enums.SortMode) {
 	})
 }
 
-// cycleFilterMode cycles through filter modes: all -> running -> success -> failed -> all
+// cycleFilterMode cycles through filter modes: all -> running -> success -> failed -> idle -> all
 func (s *Server) cycleFilterMode(current enums.FilterMode) enums.FilterMode {
 	switch current {
 	case enums.FilterModeAll:
@@ -559,6 +566,8 @@ func (s *Server) cycleFilterMode(current enums.FilterMode) enums.FilterMode {
 	case enums.FilterModeSuccess:
 		return enums.FilterModeFailed
 	case enums.FilterModeFailed:
+		return enums.FilterModeIdle
+	case enums.FilterModeIdle:
 		return enums.FilterModeAll
 	default:
 		return enums.FilterModeAll

--- a/e2e/controls_test.go
+++ b/e2e/controls_test.go
@@ -150,8 +150,8 @@ func TestFilter_FullCycle(t *testing.T) {
 	navigateToDashboard(t, page)
 	waitForJobsLoaded(t, page)
 
-	// cycle through all filter modes: all -> running -> success -> failed -> all
-	modes := []string{"All Jobs", "Running", "Success", "Failed", "All Jobs"}
+	// cycle through all filter modes: all -> running -> success -> failed -> idle -> all
+	modes := []string{"All Jobs", "Running", "Success", "Failed", "Idle", "All Jobs"}
 
 	for i, expected := range modes {
 		text, err := page.Locator(".filter-button .filter-label").TextContent()
@@ -163,6 +163,41 @@ func TestFilter_FullCycle(t *testing.T) {
 			require.NoError(t, page.Locator(".filter-button .filter-label:has-text('"+modes[i+1]+"')").WaitFor())
 		}
 	}
+}
+
+func TestFilter_BreakdownClickFilters(t *testing.T) {
+	page := newPage(t)
+	navigateToDashboard(t, page)
+	waitForJobsLoaded(t, page)
+
+	// click the "idle" breakdown item in the Total tile
+	require.NoError(t, page.Locator(".breakdown-idle").Click())
+
+	// breakdown item becomes active and filter button reflects the selected mode
+	require.NoError(t, page.Locator(".breakdown-idle.active").WaitFor())
+	require.NoError(t, page.Locator(".filter-button .filter-label:has-text('Idle')").WaitFor())
+
+	label, err := page.Locator(".filter-button .filter-label").TextContent()
+	require.NoError(t, err)
+	assert.Contains(t, label, "Idle")
+
+	// every visible job card must match the idle filter
+	nonIdle, err := page.Locator(".job-card:not([data-job-status='idle'])").Count()
+	require.NoError(t, err)
+	assert.Equal(t, 0, nonIdle, "only idle jobs should be visible after filtering by idle")
+
+	idle, err := page.Locator(".job-card").Count()
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, idle, 1, "should show at least one idle job")
+
+	// clicking the Total tile clears the filter back to all
+	require.NoError(t, page.Locator(".stat-total").Click())
+	require.NoError(t, page.Locator(".stat-total.active").WaitFor())
+	require.NoError(t, page.Locator(".filter-button .filter-label:has-text('All Jobs')").WaitFor())
+
+	label, err = page.Locator(".filter-button .filter-label").TextContent()
+	require.NoError(t, err)
+	assert.Contains(t, label, "All Jobs")
 }
 
 func TestSort_FullCycle(t *testing.T) {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -20,6 +20,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -376,6 +378,37 @@ func TestDashboard_ShowsStatsBar(t *testing.T) {
 	visible, err := page.Locator(".stats-bar").IsVisible()
 	require.NoError(t, err)
 	assert.True(t, visible, "stats bar should be visible")
+}
+
+func TestDashboard_ShowsStatsBreakdown(t *testing.T) {
+	page := newPage(t)
+	navigateToDashboard(t, page)
+
+	// breakdown line under the total tile should be visible
+	visible, err := page.Locator(".stat-breakdown").IsVisible()
+	require.NoError(t, err)
+	assert.True(t, visible, "stats breakdown should be visible")
+
+	// counts depend on shared server state mutated by other tests, so assert the
+	// invariant total == running + success + failed + idle rather than fixed numbers
+	total := statCount(t, page, "#total-count")
+	running := statCount(t, page, "#running-count")
+	success := statCount(t, page, "#success-count")
+	failed := statCount(t, page, "#failed-count")
+	idle := statCount(t, page, "#idle-count")
+
+	assert.Equal(t, 4, total, "should have the 4 crontab jobs")
+	assert.Equal(t, total, running+success+failed+idle, "breakdown should sum to total")
+}
+
+// statCount reads the integer text content of a stat span by selector
+func statCount(t *testing.T, page playwright.Page, selector string) int {
+	t.Helper()
+	text, err := page.Locator(selector).TextContent()
+	require.NoError(t, err)
+	n, err := strconv.Atoi(strings.TrimSpace(text))
+	require.NoError(t, err, "stat %s should be an integer, got %q", selector, text)
+	return n
 }
 
 func TestDashboard_HasSearchBox(t *testing.T) {

--- a/e2e/toggle_test.go
+++ b/e2e/toggle_test.go
@@ -256,11 +256,8 @@ func TestToggle_WorksInListView(t *testing.T) {
 	require.NoError(t, page.Locator(".view-toggle").Click())
 	waitVisible(t, page.Locator(".jobs-table"))
 
-	// click toggle on first row
-	require.NoError(t, page.Locator(".job-row .btn-toggle").First().Click())
-
-	// wait for HTMX refresh
-	require.NoError(t, page.Locator(".job-row.job-disabled").First().WaitFor())
+	// click toggle on first row; retry to survive races with the 5s auto-refresh poll swapping the table
+	clickUntilVisible(t, page.Locator(".job-row .btn-toggle").First(), page.Locator(".job-row.job-disabled").First())
 
 	count, err := page.Locator(".job-row.job-disabled").Count()
 	require.NoError(t, err)

--- a/e2e/toggle_test.go
+++ b/e2e/toggle_test.go
@@ -256,8 +256,12 @@ func TestToggle_WorksInListView(t *testing.T) {
 	require.NoError(t, page.Locator(".view-toggle").Click())
 	waitVisible(t, page.Locator(".jobs-table"))
 
-	// click toggle on first row; retry to survive races with the 5s auto-refresh poll swapping the table
-	clickUntilVisible(t, page.Locator(".job-row .btn-toggle").First(), page.Locator(".job-row.job-disabled").First())
+	// click toggle once, awaiting the toggle request so a 5s poll swap can't drop the click or double-toggle
+	_, err := page.ExpectResponse(togglePathRe, func() error {
+		return page.Locator(".job-row .btn-toggle").First().Click()
+	})
+	require.NoError(t, err)
+	require.NoError(t, page.Locator(".job-row.job-disabled").First().WaitFor())
 
 	count, err := page.Locator(".job-row.job-disabled").Count()
 	require.NoError(t, err)


### PR DESCRIPTION
adds a success/failed/idle breakdown to the Total Jobs tile on the web dashboard. The total and each breakdown count are clickable to filter jobs by that status, kept in sync with the existing filter button in both directions.

idle becomes a first-class filter mode (the cycle is now all, running, success, failed, idle, back to all), and idle status uses a muted amber across the card view, list view, and the breakdown.

**what changed**
- new `FilterModeIdle` enum; `filterJobs` handles idle; the filter cycle includes idle
- new `POST /api/filter-mode` endpoint for direct filter selection (the toggle button still cycles)
- `stats-total` and `stats-breakdown` are OOB-swappable templates, re-rendered on the 5s poll and on every filter change so counts and the active highlight stay live
- enums regenerated with the current generator, which also makes `Parse*` case-insensitive

**tests**
- handler tests for `/api/filter-mode` (set + invalid fallback) and idle filtering
- e2e coverage for breakdown and total clicks
- fixed a flaky `TestToggle_WorksInListView` (poll vs click race) with the existing retry helper

**docs**
- README web dashboard section updated for the idle filter and clickable breakdown
- CLAUDE.md gains the e2e test conventions and the bounded-test-run note
